### PR TITLE
Fix npm org scope to @ai-1luvc0d3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The most feature-rich [MCP](https://modelcontextprotocol.io/) server for [Metaba
 
 There are other Metabase MCP servers. Here's why this one is different:
 
-| Feature | @npm-ai-1luvc0d3/metabase-mcp | Others |
+| Feature | @ai-1luvc0d3/metabase-mcp | Others |
 |---------|:--:|:--:|
 | Purpose-built tools | **28** | 4-19 |
 | Natural language to SQL | **Yes** | No |
@@ -32,13 +32,13 @@ There are other Metabase MCP servers. Here's why this one is different:
 ### Using npx (recommended)
 
 ```bash
-npx @npm-ai-1luvc0d3/metabase-mcp
+npx @ai-1luvc0d3/metabase-mcp
 ```
 
 ### Manual install
 
 ```bash
-npm install -g @npm-ai-1luvc0d3/metabase-mcp
+npm install -g @ai-1luvc0d3/metabase-mcp
 metabase-mcp
 ```
 
@@ -83,7 +83,7 @@ Add to your Claude Desktop config (`~/Library/Application Support/Claude/claude_
   "mcpServers": {
     "metabase": {
       "command": "npx",
-      "args": ["@npm-ai-1luvc0d3/metabase-mcp"],
+      "args": ["@ai-1luvc0d3/metabase-mcp"],
       "env": {
         "METABASE_URL": "https://your-metabase.example.com",
         "METABASE_API_KEY": "mb_your_api_key_here",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@npm-ai-1luvc0d3/metabase-mcp",
+  "name": "@ai-1luvc0d3/metabase-mcp",
   "version": "1.0.0",
   "description": "MCP server connecting Claude to Metabase for data analysis",
   "type": "module",


### PR DESCRIPTION
## Summary
- Update package name from `@npm-ai-1luvc0d3/metabase-mcp` to `@ai-1luvc0d3/metabase-mcp` to match actual npm org name

## Test plan
- [x] CI passes
- [ ] `npm publish --access public` succeeds after merge