### PR TITLE
Fix security vulnerabilities from audit

### DIFF
--- a/src/client/metabase-client.ts
+++ b/src/client/metabase-client.ts
@@ -47,12 +47,18 @@ export class MetabaseClient {
 
       const response = await fetch(url, {
         ...options,
+        redirect: 'manual',
         signal: controller.signal,
         headers: {
           ...headers,
           ...options?.headers,
         },
       });
+
+      // Reject redirects to prevent leaking API key to redirect targets
+      if (response.status >= 300 && response.status < 400) {
+        throw new MetabaseError(response.status, 'Redirect not allowed');
+      }
 
       if (!response.ok) {
         const body = await response.text();

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,9 +49,12 @@ async function main() {
     logger.warn('ANTHROPIC_API_KEY not set - NLQ features disabled');
   }
 
-  // Create tool context
+  // Create tool context — expose only safe config subset (no API keys)
   const toolContext: ToolContext = {
-    config,
+    config: {
+      mode: config.mode,
+      metabase: { maxRows: config.metabase.maxRows },
+    },
     metabaseClient,
     llmService,
     sqlGuardrails,

--- a/src/security/audit-logger.ts
+++ b/src/security/audit-logger.ts
@@ -3,7 +3,7 @@
  * Logs all operations for security auditing and debugging
  */
 
-import { appendFileSync, existsSync, mkdirSync } from 'fs';
+import { appendFileSync, existsSync, mkdirSync, writeFileSync } from 'fs';
 import { dirname } from 'path';
 
 export interface AuditEvent {
@@ -28,11 +28,14 @@ export class AuditLogger {
     this.logFile = config.logFile ?? null;
     this.alertOnHighRisk = config.alertOnHighRisk ?? true;
 
-    // Ensure log directory exists
+    // Ensure log directory and file exist with secure permissions
     if (this.logFile) {
       const dir = dirname(this.logFile);
       if (!existsSync(dir)) {
-        mkdirSync(dir, { recursive: true });
+        mkdirSync(dir, { recursive: true, mode: 0o700 });
+      }
+      if (!existsSync(this.logFile)) {
+        writeFileSync(this.logFile, '', { mode: 0o600 });
       }
     }
   }

--- a/src/tools/nlq-tools.ts
+++ b/src/tools/nlq-tools.ts
@@ -137,12 +137,16 @@ export function registerNLQTools(server: McpServer, ctx: ToolContext): void {
         // Optionally get execution plan
         let executionPlan: string | undefined;
         if (database_id) {
-          try {
-            const explainSQL = `EXPLAIN ${sql}`;
-            const result = await ctx.metabaseClient.executeQuery(database_id, explainSQL);
-            executionPlan = JSON.stringify(result.data.rows, null, 2);
-          } catch {
-            // EXPLAIN might not be supported, continue without it
+          // Validate SQL through guardrails before executing EXPLAIN
+          const validation = ctx.sqlGuardrails.validate(sql);
+          if (validation.valid) {
+            try {
+              const explainSQL = `EXPLAIN ${validation.sanitizedSQL}`;
+              const result = await ctx.metabaseClient.executeQuery(database_id, explainSQL);
+              executionPlan = JSON.stringify(result.data.rows, null, 2);
+            } catch {
+              // EXPLAIN might not be supported, continue without it
+            }
           }
         }
 

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -3,7 +3,7 @@
  * Shared context passed to all tool handlers
  */
 
-import type { AppConfig } from '../client/types.js';
+import type { ServerMode } from '../client/types.js';
 import type { MetabaseClient } from '../client/metabase-client.js';
 import type { LLMService } from '../client/llm-service.js';
 import type { SQLGuardrails } from '../security/sql-guardrails.js';
@@ -12,8 +12,19 @@ import type { AuditLogger } from '../security/audit-logger.js';
 import type { SchemaManager } from '../utils/schema-manager.js';
 import type { Logger } from '../config.js';
 
+/**
+ * Subset of config exposed to tool handlers.
+ * Intentionally excludes API keys and other secrets.
+ */
+export interface ToolConfig {
+  mode: ServerMode;
+  metabase: {
+    maxRows: number;
+  };
+}
+
 export interface ToolContext {
-  config: AppConfig;
+  config: ToolConfig;
   metabaseClient: MetabaseClient;
   llmService: LLMService | null;
   sqlGuardrails: SQLGuardrails;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -39,8 +39,17 @@ export class MetabaseError extends Error {
     return {
       error: this.message,
       statusCode: this.statusCode,
-      details: this.responseBody,
+      details: this.sanitizeResponse(this.responseBody),
     };
+  }
+
+  private sanitizeResponse(body: string): string {
+    // Truncate long responses and redact potential secrets
+    const truncated = body.length > 500 ? body.substring(0, 500) + '... [truncated]' : body;
+    return truncated
+      .replace(/sk-[a-zA-Z0-9_-]{20,}/g, '[REDACTED]')
+      .replace(/mb_[a-zA-Z0-9_-]{10,}/g, '[REDACTED]')
+      .replace(/Bearer\s+[a-zA-Z0-9._-]+/gi, 'Bearer [REDACTED]');
   }
 }
 

--- a/tests/integration/nlq-tools.test.ts
+++ b/tests/integration/nlq-tools.test.ts
@@ -597,7 +597,7 @@ describe('NLQ Tools Integration', () => {
           database_id: 1,
         });
 
-        expect(mockClient.executeQuery).toHaveBeenCalledWith(1, 'EXPLAIN SELECT * FROM users');
+        expect(mockClient.executeQuery).toHaveBeenCalledWith(1, 'EXPLAIN SELECT * FROM users LIMIT 1000');
       });
 
       it('passes execution plan to LLM service', async () => {


### PR DESCRIPTION
## Summary

Fixes 5 security vulnerabilities identified during a full repo security audit.

### HIGH severity
- **SQL injection via EXPLAIN**: `optimize_sql` was executing `EXPLAIN ${sql}` without passing user input through SQL guardrails first. Now validates and sanitizes SQL before constructing the EXPLAIN query.

### MEDIUM severity  
- **Unsanitized Metabase error responses**: `MetabaseError.toJSON()` returned raw Metabase response bodies which could contain auth tokens or internal details. Now truncates to 500 chars and redacts API key patterns.
- **Insecure audit log permissions**: Log directory created with default 755 perms and files with 644 (world-readable). Now uses 700 for dirs and 600 for files.
- **Full config exposed to tools**: `ToolContext` included the entire `AppConfig` (with `anthropicApiKey`). Now exposes only `mode` and `metabase.maxRows`.

### LOW severity
- **No redirect protection**: `MetabaseClient.fetch()` followed redirects by default, which could leak the API key header to a redirect target. Now uses `redirect: 'manual'` and rejects 3xx responses.

## Files changed
- `src/tools/nlq-tools.ts` — validate SQL before EXPLAIN
- `src/utils/errors.ts` — sanitize MetabaseError response body
- `src/security/audit-logger.ts` — secure file/dir permissions
- `src/tools/types.ts` — new `ToolConfig` type (no secrets)
- `src/index.ts` — pass safe config subset to tools
- `src/client/metabase-client.ts` — reject redirects
- `tests/integration/nlq-tools.test.ts` — update test for sanitized EXPLAIN

## Test plan
- [x] All 363 tests pass
- [x] Type check passes