### PR TITLE
Add automated npm publish on GitHub release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Run tests
+        run: npm test
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
Adds a GitHub Actions workflow that automatically publishes to npm when a GitHub release is created.

## How it works
1. Create a GitHub release (e.g. `v1.1.0`)
2. Workflow runs: type check, tests, then `npm publish`
3. Uses `NPM_TOKEN` secret for authentication

## Setup required
Add the npm granular access token as a GitHub secret:
```
gh secret set NPM_TOKEN
```
Paste the token value (`npm_lcPm...`) when prompted.

## Future releases
1. Bump version: `npm version patch|minor|major`
2. Push: `git push && git push --tags`
3. Create GitHub release from the tag
4. npm publish happens automatically

## Test plan
- [x] CI passes
- [x] After merge, add `NPM_TOKEN` secret to repo