### PR TITLE
Switch npm publish to OIDC trusted publisher

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,4 @@ jobs:
         run: npm test
 
       - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary
- Remove `NPM_TOKEN` secret dependency from publish workflow
- Use OIDC trusted publisher instead (already configured on npm)
- Add `--provenance` flag for supply chain transparency (links published package back to this repo/commit)

## What changed
- Removed `NODE_AUTH_TOKEN` env var
- Added `--provenance` flag to `npm publish`
- `id-token: write` permission was already set

## After merge
You can delete the `NPM_TOKEN` secret from the repo since it's no longer needed:
```
gh secret delete NPM_TOKEN --repo 1luvc0d3/metabase-mcp
```

## Test plan
- [x] CI passes
- [ ] Next release publishes successfully via OIDC