### PR TITLE
Bump version to v1.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metabase-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metabase-mcp",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-1luvc0d3/metabase-mcp",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "MCP server connecting Claude to Metabase for data analysis",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Bumps package version from 1.0.0 to 1.0.1 to enable publishing a GitHub release (which populates the Releases sidebar and tests the OIDC automated publish pipeline end-to-end).

## Changes
- `package.json`: version 1.0.0 → 1.0.1
- `package-lock.json`: version 1.0.0 → 1.0.1

## After merge
Run: `gh release create v1.0.1 --title "v1.0.1" --notes "..."`

This triggers `publish.yml` which:
1. Runs tests via OIDC-authenticated workflow
2. Publishes to npm automatically (no token needed)
3. Adds entry to Releases sidebar

## Test plan
- [x] CI passes