### PR TITLE
Fix: upgrade npm to v11+ for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,9 @@ jobs:
           cache: npm
           registry-url: https://registry.npmjs.org
 
+      - name: Upgrade npm (required for OIDC trusted publishing)
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary
The v1.0.1 release failed to publish to npm with a cryptic 404 error. Root cause: Node 20 ships with npm 10, but OIDC trusted publishers require **npm CLI v11+**.

Fix: upgrade npm before publishing.

## The error
\`\`\`
npm error 404 Not Found - PUT https://registry.npmjs.org/@ai-1luvc0d3%2fmetabase-mcp
npm error 404  '@ai-1luvc0d3/metabase-mcp@1.0.1' is not in this registry.
\`\`\`

This was actually an auth failure — the old npm CLI doesn't know how to exchange GitHub OIDC tokens for npm auth tokens.

## After merge
Re-publish v1.0.1 by deleting and recreating the release:
\`\`\`
gh release delete v1.0.1 --yes --cleanup-tag
gh release create v1.0.1 --title "v1.0.1" --notes "..."
\`\`\`

## Test plan
- [x] CI passes
- [ ] Next release triggers successful npm publish via OIDC