### PR TITLE
Bump version to v1.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "metabase-mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "metabase-mcp",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-1luvc0d3/metabase-mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "MCP server connecting Claude to Metabase for data analysis",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Validates the OIDC publish pipeline with the npm v11+ fix from PR #22.

## Test plan
- [ ] CI passes
- [ ] After merge, release v1.0.2 triggers successful npm publish