### PR TITLE
Fix code scanning alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/test-connection.mjs
+++ b/test-connection.mjs
@@ -37,7 +37,7 @@ if (!apiKey) {
   process.exit(1);
 }
 
-console.log('API Key:', apiKey.substring(0, 15) + '...');
+console.log('API Key: [configured]');
 console.log('');
 
 const headers = {


### PR DESCRIPTION
## Summary
Fixes both open CodeQL alerts.

### Alert #2: Clear-text logging of sensitive information (high)
**File**: `test-connection.mjs:40`

Before: `console.log('API Key:', apiKey.substring(0, 15) + '...')`
After: `console.log('API Key: [configured]')`

Even the first 15 chars of an API key is meaningful leakage. Metabase keys have a short \`mb_\` prefix, so 15 chars = ~12 chars of secret material.

### Alert #1: Workflow does not contain permissions (medium)
**File**: `.github/workflows/ci.yml`

Added explicit \`permissions: contents: read\` at the workflow level. Without this, the workflow gets the repo's default permissions, which can be broader than needed. Least-privilege principle.

## Test plan
- [x] CI passes
- [ ] CodeQL alerts close automatically after merge