### PR TITLE
Bump version to v1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ai-1luvc0d3/metabase-mcp",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ai-1luvc0d3/metabase-mcp",
-      "version": "1.0.2",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.52.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-1luvc0d3/metabase-mcp",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "MCP server connecting Claude to Metabase for data analysis",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
Minor version bump for v1.1.0 release, which ships the .mcpb one-click install bundle (#14).

## Highlights
- .mcpb Claude Desktop Extension with guided config UI
- 5 concrete usage examples in README
- All existing security/CI posture preserved

## After merge
`gh release create v1.1.0` → OIDC npm publish + .mcpb uploaded as release artifact

## Test plan
- [x] CI passes