### PR TITLE
Comply with Anthropic MCP Directory Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,60 @@ This server is designed for production use with multiple layers of protection:
 
 When using NLQ or insight tools (`ask_data`, `generate_insights`, etc.), **query result data is sent to the Anthropic API** for analysis. If your queries return sensitive data (PII, financial records, etc.), that data will be processed by Claude. Consider this when enabling NLQ features on databases containing sensitive information.
 
+## Privacy Policy
+
+**What this extension collects:**
+- Your Metabase API key and URL (stored locally in the OS keychain — never transmitted to us)
+- Your Anthropic API key, if provided (stored locally in the OS keychain — never transmitted to us)
+- No telemetry, analytics, or usage data is collected by this extension
+
+**What this extension transmits:**
+- All Metabase API calls (queries, dashboards, cards) go directly from your machine to your own Metabase instance
+- NLQ/insight tool usage sends your natural-language question, database schema context, and query result samples to the Anthropic API for processing (governed by [Anthropic's privacy policy](https://www.anthropic.com/legal/privacy))
+- If you don't provide an Anthropic API key, no data is sent to Anthropic — NLQ and insight tools are simply disabled
+
+**Data retention:**
+- This extension does not retain any data. Audit logs (if enabled via `AUDIT_LOG_FILE`) are written to your local filesystem only, with owner-only permissions (0600)
+
+**Third-party privacy policies:**
+- [Metabase Privacy Policy](https://www.metabase.com/privacy)
+- [Anthropic Privacy Policy](https://www.anthropic.com/legal/privacy)
+
+**Reporting security issues:** See [SECURITY.md](SECURITY.md) for responsible disclosure.
+
+## Troubleshooting
+
+### "Cannot connect to Metabase" / 401 errors
+- Verify `METABASE_URL` is correct and reachable (test: `curl $METABASE_URL/api/health`)
+- Verify `METABASE_API_KEY` is valid (regenerate in Metabase Admin > Settings > API Keys if needed)
+- The API key must have permissions for the databases you want to query
+
+### "Blocked SQL pattern detected" errors
+- Only `SELECT` and `WITH` queries are allowed by default
+- Even inside a `SELECT`, patterns like `UNION SELECT`, SQL comments (`--`, `/* */`), `xp_cmdshell`, `INTO OUTFILE`, etc. are blocked
+- To execute DML (`INSERT`, `UPDATE`, `DELETE`), you must run in `write` or `full` mode AND the SQL must still pass guardrails (it won't — by design)
+
+### "Rate limit exceeded" errors
+- Default limits: 120 reads/min, 30 writes/min, 20 LLM calls/min
+- Adjust with `RATE_LIMIT_REQUESTS_PER_MINUTE` env var
+- Wait for the retry-after period shown in the error
+
+### NLQ tools unavailable
+- Requires `ANTHROPIC_API_KEY` — verify it's set
+- Check it starts with `sk-` and has remaining credits
+- Insight tools additionally require `MCP_MODE=full`
+
+### Claude Desktop: extension installed but tools not appearing
+- Fully quit and restart Claude Desktop
+- Check logs: `~/Library/Logs/Claude/mcp*.log` on macOS
+- Verify `node --version` is >= 18
+
+## Support
+
+- **Bug reports / feature requests:** [GitHub Issues](https://github.com/1luvc0d3/metabase-mcp/issues)
+- **Security vulnerabilities:** [Private disclosure](https://github.com/1luvc0d3/metabase-mcp/security/advisories/new) — see [SECURITY.md](SECURITY.md)
+- **Response time:** typically within 5 business days
+
 ## Development
 
 ```bash

--- a/src/tools/insight-tools.ts
+++ b/src/tools/insight-tools.ts
@@ -28,6 +28,7 @@ export function registerInsightTools(server: McpServer, ctx: ToolContext): void 
       database_id: z.number().describe('Database ID to query'),
       tables: z.array(z.string()).optional().describe('Specific tables to consider'),
     },
+    { title: 'Ask Data Question', readOnlyHint: true, openWorldHint: true },
     async ({ question, database_id, tables }) => {
       try {
         ctx.rateLimiter.checkLimit('nlq');
@@ -103,6 +104,7 @@ export function registerInsightTools(server: McpServer, ctx: ToolContext): void 
     {
       card_id: z.number().describe('Card ID to analyze'),
     },
+    { title: 'Generate Insights', readOnlyHint: true, openWorldHint: true },
     async ({ card_id }) => {
       try {
         ctx.rateLimiter.checkLimit('nlq');
@@ -157,6 +159,7 @@ export function registerInsightTools(server: McpServer, ctx: ToolContext): void 
       database_id: z.number().describe('Database ID'),
       tables: z.array(z.string()).optional().describe('Specific tables to use'),
     },
+    { title: 'Compare Metrics', readOnlyHint: true, openWorldHint: true },
     async ({ question, database_id, tables }) => {
       try {
         ctx.rateLimiter.checkLimit('nlq');
@@ -228,6 +231,7 @@ export function registerInsightTools(server: McpServer, ctx: ToolContext): void 
       database_id: z.number().describe('Database ID'),
       tables: z.array(z.string()).optional().describe('Specific tables to use'),
     },
+    { title: 'Trend Analysis', readOnlyHint: true, openWorldHint: true },
     async ({ question, database_id, tables }) => {
       try {
         ctx.rateLimiter.checkLimit('nlq');

--- a/src/tools/nlq-tools.ts
+++ b/src/tools/nlq-tools.ts
@@ -28,6 +28,7 @@ export function registerNLQTools(server: McpServer, ctx: ToolContext): void {
       database_id: z.number().describe('Database ID to query'),
       tables: z.array(z.string()).optional().describe('Specific tables to consider (for large schemas)'),
     },
+    { title: 'Natural Language to SQL', readOnlyHint: true, openWorldHint: true },
     async ({ question, database_id, tables }) => {
       try {
         ctx.rateLimiter.checkLimit('nlq');
@@ -102,6 +103,7 @@ export function registerNLQTools(server: McpServer, ctx: ToolContext): void {
     {
       sql: z.string().describe('SQL query to explain'),
     },
+    { title: 'Explain SQL', readOnlyHint: true, openWorldHint: true },
     async ({ sql }) => {
       try {
         ctx.rateLimiter.checkLimit('nlq');
@@ -130,6 +132,7 @@ export function registerNLQTools(server: McpServer, ctx: ToolContext): void {
       sql: z.string().describe('SQL query to optimize'),
       database_id: z.number().optional().describe('Database ID (to run EXPLAIN if available)'),
     },
+    { title: 'Optimize SQL', readOnlyHint: true, openWorldHint: true },
     async ({ sql, database_id }) => {
       try {
         ctx.rateLimiter.checkLimit('nlq');
@@ -174,6 +177,7 @@ export function registerNLQTools(server: McpServer, ctx: ToolContext): void {
     {
       sql: z.string().describe('SQL query to validate'),
     },
+    { title: 'Validate SQL', readOnlyHint: true, idempotentHint: true },
     async ({ sql }) => {
       try {
         ctx.rateLimiter.checkLimit('read'); // Use read tier since no LLM call

--- a/src/tools/read-tools.ts
+++ b/src/tools/read-tools.ts
@@ -17,6 +17,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
     'list_dashboards',
     'List all dashboards in Metabase',
     {},
+    { title: 'List Dashboards', readOnlyHint: true, idempotentHint: true, openWorldHint: true },
     async () => {
       try {
         ctx.rateLimiter.checkLimit('read');
@@ -49,6 +50,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
     {
       dashboard_id: z.number().describe('Dashboard ID'),
     },
+    { title: 'Get Dashboard', readOnlyHint: true, idempotentHint: true, openWorldHint: true },
     async ({ dashboard_id }) => {
       try {
         ctx.rateLimiter.checkLimit('read');
@@ -73,6 +75,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
       collection_id: z.number().optional().describe('Filter by collection ID'),
       limit: z.number().min(1).max(100).default(100).optional().describe('Max cards to return (default 100)'),
     },
+    { title: 'List Cards', readOnlyHint: true, idempotentHint: true, openWorldHint: true },
     async ({ collection_id, limit }) => {
       try {
         ctx.rateLimiter.checkLimit('read');
@@ -116,6 +119,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
     {
       card_id: z.number().describe('Card ID'),
     },
+    { title: 'Get Card', readOnlyHint: true, idempotentHint: true, openWorldHint: true },
     async ({ card_id }) => {
       try {
         ctx.rateLimiter.checkLimit('read');
@@ -140,6 +144,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
       card_id: z.number().describe('Card ID to execute'),
       parameters: z.record(z.unknown()).optional().describe('Optional parameters for parameterized queries'),
     },
+    { title: 'Execute Card', readOnlyHint: true, idempotentHint: true, openWorldHint: true },
     async ({ card_id, parameters }) => {
       try {
         ctx.rateLimiter.checkLimit('read');
@@ -174,6 +179,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
     'list_databases',
     'List all connected databases',
     {},
+    { title: 'List Databases', readOnlyHint: true, idempotentHint: true, openWorldHint: true },
     async () => {
       try {
         ctx.rateLimiter.checkLimit('read');
@@ -206,6 +212,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
     {
       database_id: z.number().describe('Database ID'),
     },
+    { title: 'Get Database Schema', readOnlyHint: true, idempotentHint: true, openWorldHint: true },
     async ({ database_id }) => {
       try {
         ctx.rateLimiter.checkLimit('read');
@@ -233,6 +240,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
       database_id: z.number().describe('Database ID to query'),
       sql: z.string().describe('SQL query (SELECT statements only)'),
     },
+    { title: 'Execute SQL Query', readOnlyHint: true, openWorldHint: true },
     async ({ database_id, sql }) => {
       try {
         ctx.rateLimiter.checkLimit('read');
@@ -289,6 +297,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
       type: z.enum(['card', 'dashboard', 'collection', 'database', 'table']).optional()
         .describe('Filter by content type'),
     },
+    { title: 'Search Content', readOnlyHint: true, idempotentHint: true, openWorldHint: true },
     async ({ query, type }) => {
       try {
         ctx.rateLimiter.checkLimit('read');
@@ -324,6 +333,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
     'get_collections',
     'List all collections',
     {},
+    { title: 'Get Collections', readOnlyHint: true, idempotentHint: true, openWorldHint: true },
     async () => {
       try {
         ctx.rateLimiter.checkLimit('read');

--- a/src/tools/write-tools.ts
+++ b/src/tools/write-tools.ts
@@ -25,6 +25,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
       display: z.enum(['table', 'bar', 'line', 'pie', 'scalar', 'row', 'area', 'combo', 'pivot', 'smartscalar', 'progress', 'funnel', 'waterfall', 'map'])
         .default('table').describe('Visualization type'),
     },
+    { title: 'Create Card', destructiveHint: false, openWorldHint: true },
     async ({ name, database_id, sql, collection_id, description, display }) => {
       try {
         ctx.rateLimiter.checkLimit('write');
@@ -82,6 +83,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
       collection_id: z.number().optional().describe('Move to collection'),
       display: z.string().optional().describe('Change visualization type'),
     },
+    { title: 'Update Card', destructiveHint: true, openWorldHint: true },
     async ({ card_id, name, description, sql, collection_id, display }) => {
       try {
         ctx.rateLimiter.checkLimit('write');
@@ -137,6 +139,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
     {
       card_id: z.number().describe('Card ID to delete'),
     },
+    { title: 'Delete Card', destructiveHint: true, openWorldHint: true },
     async ({ card_id }) => {
       try {
         ctx.rateLimiter.checkLimit('write');
@@ -165,6 +168,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
       description: z.string().optional().describe('Dashboard description'),
       collection_id: z.number().optional().describe('Collection to save to'),
     },
+    { title: 'Create Dashboard', destructiveHint: false, openWorldHint: true },
     async ({ name, description, collection_id }) => {
       try {
         ctx.rateLimiter.checkLimit('write');
@@ -205,6 +209,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
       description: z.string().optional().describe('New description'),
       collection_id: z.number().optional().describe('Move to collection'),
     },
+    { title: 'Update Dashboard', destructiveHint: true, openWorldHint: true },
     async ({ dashboard_id, name, description, collection_id }) => {
       try {
         ctx.rateLimiter.checkLimit('write');
@@ -241,6 +246,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
     {
       dashboard_id: z.number().describe('Dashboard ID to delete'),
     },
+    { title: 'Delete Dashboard', destructiveHint: true, openWorldHint: true },
     async ({ dashboard_id }) => {
       try {
         ctx.rateLimiter.checkLimit('write');
@@ -272,6 +278,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
       size_x: z.number().optional().default(4).describe('Width (in grid units)'),
       size_y: z.number().optional().default(4).describe('Height (in grid units)'),
     },
+    { title: 'Add Card to Dashboard', destructiveHint: false, openWorldHint: true },
     async ({ dashboard_id, card_id, row, col, size_x, size_y }) => {
       try {
         ctx.rateLimiter.checkLimit('write');
@@ -306,6 +313,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
       dashboard_id: z.number().describe('Dashboard ID'),
       dashcard_id: z.number().describe('Dashboard card ID (not the card ID)'),
     },
+    { title: 'Remove Card from Dashboard', destructiveHint: true, openWorldHint: true },
     async ({ dashboard_id, dashcard_id }) => {
       try {
         ctx.rateLimiter.checkLimit('write');
@@ -335,6 +343,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
       color: z.string().optional().describe('Collection color (hex code)'),
       parent_id: z.number().optional().describe('Parent collection ID'),
     },
+    { title: 'Create Collection', destructiveHint: false, openWorldHint: true },
     async ({ name, description, color, parent_id }) => {
       try {
         ctx.rateLimiter.checkLimit('write');
@@ -375,6 +384,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
       item_id: z.number().describe('ID of the item to move'),
       collection_id: z.number().describe('Target collection ID'),
     },
+    { title: 'Move to Collection', destructiveHint: true, openWorldHint: true },
     async ({ item_type, item_id, collection_id }) => {
       try {
         ctx.rateLimiter.checkLimit('write');

--- a/tests/integration/nlq-tools.test.ts
+++ b/tests/integration/nlq-tools.test.ts
@@ -105,7 +105,7 @@ describe('NLQ Tools Integration', () => {
     registeredTools = new Map();
     const originalTool = server.tool.bind(server);
     vi.spyOn(server, 'tool').mockImplementation((name: string, ...args: any[]) => {
-      registeredTools.set(name, args);
+      const handler = args[args.length - 1]; registeredTools.set(name, { args, handler });
       return originalTool(name, ...args);
     });
 
@@ -151,7 +151,7 @@ describe('NLQ Tools Integration', () => {
   describe('nlq_to_sql', () => {
     describe('Successful SQL Generation', () => {
       it('converts natural language question to SQL', async () => {
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         const result = await handler({
           question: 'How many orders does each user have?',
           database_id: 1,
@@ -165,7 +165,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('includes explanation in response when available', async () => {
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         const result = await handler({
           question: 'Show me all active users',
           database_id: 1,
@@ -177,7 +177,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('fetches database schema for SQL generation', async () => {
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         await handler({
           question: 'List all products',
           database_id: 1,
@@ -187,7 +187,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('passes schema to LLM service', async () => {
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         await handler({
           question: 'Get user emails',
           database_id: 1,
@@ -206,7 +206,7 @@ describe('NLQ Tools Integration', () => {
 
     describe('Table Filtering', () => {
       it('filters schema to specified tables when tables parameter is provided', async () => {
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         await handler({
           question: 'Show user order counts',
           database_id: 1,
@@ -225,7 +225,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('handles case-insensitive table name filtering', async () => {
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         await handler({
           question: 'Show user order counts',
           database_id: 1,
@@ -239,7 +239,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('returns empty tables array when no matching tables found', async () => {
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         await handler({
           question: 'Show data from nonexistent table',
           database_id: 1,
@@ -271,7 +271,7 @@ describe('NLQ Tools Integration', () => {
           tables: largeTables,
         });
 
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         await handler({
           question: 'Show me sales data',
           database_id: 1,
@@ -282,7 +282,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('does not filter tables for small schemas (<=50 tables)', async () => {
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         await handler({
           question: 'Show me user data',
           database_id: 1,
@@ -295,7 +295,7 @@ describe('NLQ Tools Integration', () => {
 
     describe('SQL Validation', () => {
       it('validates generated SQL before returning', async () => {
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         const result = await handler({
           question: 'Get all users',
           database_id: 1,
@@ -313,7 +313,7 @@ describe('NLQ Tools Integration', () => {
           explanation: 'Dangerous query',
         });
 
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         const result = await handler({
           question: 'Delete all users',
           database_id: 1,
@@ -327,7 +327,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('returns sanitized SQL in response', async () => {
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         const result = await handler({
           question: 'Get all users',
           database_id: 1,
@@ -346,7 +346,7 @@ describe('NLQ Tools Integration', () => {
           explanation: 'Query without LIMIT',
         });
 
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         const result = await handler({
           question: 'Get all users',
           database_id: 1,
@@ -362,7 +362,7 @@ describe('NLQ Tools Integration', () => {
       it('returns error when LLM service fails', async () => {
         mockLLMService.generateSQL.mockRejectedValueOnce(new Error('API rate limit exceeded'));
 
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         const result = await handler({
           question: 'Get all users',
           database_id: 1,
@@ -376,7 +376,7 @@ describe('NLQ Tools Integration', () => {
       it('returns error when database schema fetch fails', async () => {
         mockClient.getDatabaseSchema.mockRejectedValueOnce(new Error('Database not found'));
 
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         const result = await handler({
           question: 'Get all users',
           database_id: 999,
@@ -388,7 +388,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('respects rate limiting', async () => {
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
 
         // Fill up NLQ rate limit (default is 20 per minute)
         for (let i = 0; i < 20; i++) {
@@ -408,7 +408,7 @@ describe('NLQ Tools Integration', () => {
       it('logs successful SQL generation', async () => {
         const logSuccessSpy = vi.spyOn(context.auditLogger, 'logSuccess');
 
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         await handler({
           question: 'Get all users',
           database_id: 1,
@@ -424,7 +424,7 @@ describe('NLQ Tools Integration', () => {
         const logFailureSpy = vi.spyOn(context.auditLogger, 'logFailure');
         mockLLMService.generateSQL.mockRejectedValueOnce(new Error('LLM error'));
 
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         await handler({
           question: 'Get all users',
           database_id: 1,
@@ -440,7 +440,7 @@ describe('NLQ Tools Integration', () => {
           explanation: 'Union injection',
         });
 
-        const handler = registeredTools.get('nlq_to_sql')?.[2];
+        const handler = registeredTools.get('nlq_to_sql')?.handler;
         await handler({
           question: 'Get passwords',
           database_id: 1,
@@ -458,7 +458,7 @@ describe('NLQ Tools Integration', () => {
   describe('explain_sql', () => {
     describe('Successful Explanation', () => {
       it('explains SQL query in plain English', async () => {
-        const handler = registeredTools.get('explain_sql')?.[2];
+        const handler = registeredTools.get('explain_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users WHERE active = true LIMIT 10',
         });
@@ -472,7 +472,7 @@ describe('NLQ Tools Integration', () => {
 
       it('returns the original SQL along with explanation', async () => {
         const testSQL = 'SELECT COUNT(*) FROM orders GROUP BY status';
-        const handler = registeredTools.get('explain_sql')?.[2];
+        const handler = registeredTools.get('explain_sql')?.handler;
         const result = await handler({
           sql: testSQL,
         });
@@ -483,7 +483,7 @@ describe('NLQ Tools Integration', () => {
 
       it('calls LLM service with the SQL query', async () => {
         const testSQL = 'SELECT * FROM products WHERE price > 100';
-        const handler = registeredTools.get('explain_sql')?.[2];
+        const handler = registeredTools.get('explain_sql')?.handler;
         await handler({ sql: testSQL });
 
         expect(mockLLMService.explainSQL).toHaveBeenCalledWith(testSQL);
@@ -494,7 +494,7 @@ describe('NLQ Tools Integration', () => {
       it('returns error when LLM service fails', async () => {
         mockLLMService.explainSQL.mockRejectedValueOnce(new Error('Explanation service unavailable'));
 
-        const handler = registeredTools.get('explain_sql')?.[2];
+        const handler = registeredTools.get('explain_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users',
         });
@@ -505,7 +505,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('respects rate limiting', async () => {
-        const handler = registeredTools.get('explain_sql')?.[2];
+        const handler = registeredTools.get('explain_sql')?.handler;
 
         // Fill up NLQ rate limit
         for (let i = 0; i < 20; i++) {
@@ -524,7 +524,7 @@ describe('NLQ Tools Integration', () => {
       it('logs successful explanation', async () => {
         const logSuccessSpy = vi.spyOn(context.auditLogger, 'logSuccess');
 
-        const handler = registeredTools.get('explain_sql')?.[2];
+        const handler = registeredTools.get('explain_sql')?.handler;
         await handler({
           sql: 'SELECT * FROM users LIMIT 10',
         });
@@ -538,7 +538,7 @@ describe('NLQ Tools Integration', () => {
         const logFailureSpy = vi.spyOn(context.auditLogger, 'logFailure');
         mockLLMService.explainSQL.mockRejectedValueOnce(new Error('LLM error'));
 
-        const handler = registeredTools.get('explain_sql')?.[2];
+        const handler = registeredTools.get('explain_sql')?.handler;
         await handler({ sql: 'SELECT 1' });
 
         expect(logFailureSpy).toHaveBeenCalled();
@@ -553,7 +553,7 @@ describe('NLQ Tools Integration', () => {
   describe('optimize_sql', () => {
     describe('Without Execution Plan', () => {
       it('returns optimization suggestions', async () => {
-        const handler = registeredTools.get('optimize_sql')?.[2];
+        const handler = registeredTools.get('optimize_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users WHERE name LIKE "%john%"',
         });
@@ -567,7 +567,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('returns optimized SQL when available', async () => {
-        const handler = registeredTools.get('optimize_sql')?.[2];
+        const handler = registeredTools.get('optimize_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users',
         });
@@ -577,7 +577,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('calls LLM service without execution plan', async () => {
-        const handler = registeredTools.get('optimize_sql')?.[2];
+        const handler = registeredTools.get('optimize_sql')?.handler;
         await handler({
           sql: 'SELECT * FROM users',
         });
@@ -591,7 +591,7 @@ describe('NLQ Tools Integration', () => {
 
     describe('With Execution Plan', () => {
       it('fetches execution plan when database_id is provided', async () => {
-        const handler = registeredTools.get('optimize_sql')?.[2];
+        const handler = registeredTools.get('optimize_sql')?.handler;
         await handler({
           sql: 'SELECT * FROM users',
           database_id: 1,
@@ -601,7 +601,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('passes execution plan to LLM service', async () => {
-        const handler = registeredTools.get('optimize_sql')?.[2];
+        const handler = registeredTools.get('optimize_sql')?.handler;
         await handler({
           sql: 'SELECT * FROM users',
           database_id: 1,
@@ -616,7 +616,7 @@ describe('NLQ Tools Integration', () => {
       it('continues without execution plan if EXPLAIN fails', async () => {
         mockClient.executeQuery.mockRejectedValueOnce(new Error('EXPLAIN not supported'));
 
-        const handler = registeredTools.get('optimize_sql')?.[2];
+        const handler = registeredTools.get('optimize_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users',
           database_id: 1,
@@ -639,7 +639,7 @@ describe('NLQ Tools Integration', () => {
           optimizedSQL: 'SELECT id, name FROM users WHERE name ILIKE $1',
         });
 
-        const handler = registeredTools.get('optimize_sql')?.[2];
+        const handler = registeredTools.get('optimize_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users WHERE LOWER(name) = LOWER("john")',
         });
@@ -654,7 +654,7 @@ describe('NLQ Tools Integration', () => {
           suggestions: ['The query is already optimal'],
         });
 
-        const handler = registeredTools.get('optimize_sql')?.[2];
+        const handler = registeredTools.get('optimize_sql')?.handler;
         const result = await handler({
           sql: 'SELECT id FROM users WHERE id = 1',
         });
@@ -669,7 +669,7 @@ describe('NLQ Tools Integration', () => {
       it('returns error when LLM service fails', async () => {
         mockLLMService.optimizeSQL.mockRejectedValueOnce(new Error('Optimization service error'));
 
-        const handler = registeredTools.get('optimize_sql')?.[2];
+        const handler = registeredTools.get('optimize_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users',
         });
@@ -684,7 +684,7 @@ describe('NLQ Tools Integration', () => {
       it('logs successful optimization', async () => {
         const logSuccessSpy = vi.spyOn(context.auditLogger, 'logSuccess');
 
-        const handler = registeredTools.get('optimize_sql')?.[2];
+        const handler = registeredTools.get('optimize_sql')?.handler;
         await handler({
           sql: 'SELECT * FROM users LIMIT 100',
         });
@@ -703,7 +703,7 @@ describe('NLQ Tools Integration', () => {
   describe('validate_sql', () => {
     describe('Valid Queries', () => {
       it('validates a simple SELECT query', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users LIMIT 10',
         });
@@ -715,7 +715,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('validates a query with JOINs', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'SELECT u.name, o.total FROM users u JOIN orders o ON u.id = o.user_id LIMIT 100',
         });
@@ -725,7 +725,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('validates a CTE (WITH) query', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: `WITH active_users AS (SELECT * FROM users WHERE active = true)
                 SELECT * FROM active_users LIMIT 50`,
@@ -736,7 +736,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('validates a query with subquery', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users WHERE id IN (SELECT user_id FROM orders) LIMIT 100',
         });
@@ -746,7 +746,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('returns sanitized SQL', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: '  SELECT   *   FROM   users   LIMIT   10  ',
         });
@@ -760,7 +760,7 @@ describe('NLQ Tools Integration', () => {
 
     describe('Invalid/Dangerous Queries', () => {
       it('rejects DROP TABLE statements', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'DROP TABLE users',
         });
@@ -771,7 +771,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('rejects DELETE statements', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'DELETE FROM users WHERE id = 1',
         });
@@ -782,7 +782,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('rejects UPDATE statements', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'UPDATE users SET active = false',
         });
@@ -793,7 +793,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('rejects INSERT statements', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: "INSERT INTO users (name) VALUES ('hacker')",
         });
@@ -804,7 +804,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('rejects TRUNCATE statements', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'TRUNCATE TABLE users',
         });
@@ -814,7 +814,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('rejects ALTER TABLE statements', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'ALTER TABLE users ADD COLUMN password TEXT',
         });
@@ -824,7 +824,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('rejects UNION-based injection attempts', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users UNION SELECT * FROM passwords',
         });
@@ -835,7 +835,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('rejects queries with SQL comments', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: "SELECT * FROM users -- WHERE admin = true",
         });
@@ -845,7 +845,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('rejects queries with block comments', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users /* comment */ WHERE id = 1',
         });
@@ -855,7 +855,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('rejects multiple statement injection', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: "SELECT * FROM users; DROP TABLE users;",
         });
@@ -865,7 +865,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('rejects time-based blind injection (SLEEP)', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users WHERE SLEEP(5)',
         });
@@ -875,7 +875,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('rejects time-based blind injection (pg_sleep)', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users WHERE pg_sleep(5)',
         });
@@ -885,7 +885,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('rejects INFORMATION_SCHEMA access', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM INFORMATION_SCHEMA.TABLES',
         });
@@ -895,7 +895,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('rejects file operations (INTO OUTFILE)', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: "SELECT * INTO OUTFILE '/tmp/data.txt' FROM users",
         });
@@ -905,7 +905,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('rejects file read operations (LOAD_FILE)', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: "SELECT LOAD_FILE('/etc/passwd')",
         });
@@ -915,7 +915,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('rejects command execution (xp_cmdshell)', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: "EXEC xp_cmdshell 'dir'",
         });
@@ -927,7 +927,7 @@ describe('NLQ Tools Integration', () => {
 
     describe('Warning Generation', () => {
       it('warns about missing LIMIT clause', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users',
         });
@@ -937,7 +937,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('warns about SELECT *', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users LIMIT 10',
         });
@@ -947,7 +947,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('warns about leading wildcards in LIKE', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: "SELECT * FROM users WHERE name LIKE '%john' LIMIT 10",
         });
@@ -957,7 +957,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('warns about CROSS JOIN', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users CROSS JOIN orders LIMIT 100',
         });
@@ -967,7 +967,7 @@ describe('NLQ Tools Integration', () => {
       });
 
       it('can return multiple warnings', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         const result = await handler({
           sql: 'SELECT * FROM users CROSS JOIN orders',
         });
@@ -979,7 +979,7 @@ describe('NLQ Tools Integration', () => {
 
     describe('Rate Limiting', () => {
       it('uses read tier rate limit (not nlq tier)', async () => {
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
 
         // Fill up read rate limit (120 per minute)
         for (let i = 0; i < 120; i++) {
@@ -998,7 +998,7 @@ describe('NLQ Tools Integration', () => {
       it('logs validation results', async () => {
         const logSuccessSpy = vi.spyOn(context.auditLogger, 'logSuccess');
 
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         await handler({
           sql: 'SELECT * FROM users LIMIT 10',
         });
@@ -1013,7 +1013,7 @@ describe('NLQ Tools Integration', () => {
       it('logs validation of invalid SQL', async () => {
         const logSuccessSpy = vi.spyOn(context.auditLogger, 'logSuccess');
 
-        const handler = registeredTools.get('validate_sql')?.[2];
+        const handler = registeredTools.get('validate_sql')?.handler;
         await handler({
           sql: 'DROP TABLE users',
         });
@@ -1033,8 +1033,8 @@ describe('NLQ Tools Integration', () => {
 
   describe('Cross-Tool Integration', () => {
     it('nlq_to_sql result can be validated with validate_sql', async () => {
-      const nlqHandler = registeredTools.get('nlq_to_sql')?.[2];
-      const validateHandler = registeredTools.get('validate_sql')?.[2];
+      const nlqHandler = registeredTools.get('nlq_to_sql')?.handler;
+      const validateHandler = registeredTools.get('validate_sql')?.handler;
 
       const nlqResult = await nlqHandler({
         question: 'Get all users',
@@ -1053,8 +1053,8 @@ describe('NLQ Tools Integration', () => {
     });
 
     it('nlq_to_sql result can be explained with explain_sql', async () => {
-      const nlqHandler = registeredTools.get('nlq_to_sql')?.[2];
-      const explainHandler = registeredTools.get('explain_sql')?.[2];
+      const nlqHandler = registeredTools.get('nlq_to_sql')?.handler;
+      const explainHandler = registeredTools.get('explain_sql')?.handler;
 
       const nlqResult = await nlqHandler({
         question: 'Count orders by status',
@@ -1074,8 +1074,8 @@ describe('NLQ Tools Integration', () => {
     });
 
     it('nlq_to_sql result can be optimized with optimize_sql', async () => {
-      const nlqHandler = registeredTools.get('nlq_to_sql')?.[2];
-      const optimizeHandler = registeredTools.get('optimize_sql')?.[2];
+      const nlqHandler = registeredTools.get('nlq_to_sql')?.handler;
+      const optimizeHandler = registeredTools.get('optimize_sql')?.handler;
 
       const nlqResult = await nlqHandler({
         question: 'Get user order totals',
@@ -1102,7 +1102,7 @@ describe('NLQ Tools Integration', () => {
 
   describe('Edge Cases', () => {
     it('handles empty question for nlq_to_sql', async () => {
-      const handler = registeredTools.get('nlq_to_sql')?.[2];
+      const handler = registeredTools.get('nlq_to_sql')?.handler;
       const result = await handler({
         question: '',
         database_id: 1,
@@ -1115,7 +1115,7 @@ describe('NLQ Tools Integration', () => {
     it('handles very long SQL for validation', async () => {
       const longSQL = 'SELECT ' + Array(100).fill('column_name').join(', ') + ' FROM users LIMIT 10';
 
-      const handler = registeredTools.get('validate_sql')?.[2];
+      const handler = registeredTools.get('validate_sql')?.handler;
       const result = await handler({
         sql: longSQL,
       });
@@ -1126,7 +1126,7 @@ describe('NLQ Tools Integration', () => {
     });
 
     it('handles SQL with special characters', async () => {
-      const handler = registeredTools.get('validate_sql')?.[2];
+      const handler = registeredTools.get('validate_sql')?.handler;
       const result = await handler({
         sql: "SELECT * FROM users WHERE name = 'O''Brien' LIMIT 10",
       });
@@ -1137,7 +1137,7 @@ describe('NLQ Tools Integration', () => {
     });
 
     it('handles unicode in SQL', async () => {
-      const handler = registeredTools.get('validate_sql')?.[2];
+      const handler = registeredTools.get('validate_sql')?.handler;
       const result = await handler({
         sql: "SELECT * FROM users WHERE city = N'Tokyo' LIMIT 10",
       });

--- a/tests/integration/read-tools.test.ts
+++ b/tests/integration/read-tools.test.ts
@@ -61,7 +61,7 @@ describe('Read Tools Integration', () => {
     registeredTools = new Map();
     const originalTool = server.tool.bind(server);
     vi.spyOn(server, 'tool').mockImplementation((name: string, ...args: any[]) => {
-      registeredTools.set(name, args);
+      const handler = args[args.length - 1]; registeredTools.set(name, { args, handler });
       return originalTool(name, ...args);
     });
 
@@ -74,7 +74,7 @@ describe('Read Tools Integration', () => {
     });
 
     it('returns list of dashboards', async () => {
-      const handler = registeredTools.get('list_dashboards')?.[2];
+      const handler = registeredTools.get('list_dashboards')?.handler;
       const result = await handler({});
 
       expect(result.isError).toBeFalsy();
@@ -85,7 +85,7 @@ describe('Read Tools Integration', () => {
     });
 
     it('respects rate limiting', async () => {
-      const handler = registeredTools.get('list_dashboards')?.[2];
+      const handler = registeredTools.get('list_dashboards')?.handler;
 
       // Fill up rate limit
       for (let i = 0; i < 120; i++) {
@@ -99,7 +99,7 @@ describe('Read Tools Integration', () => {
 
   describe('get_dashboard', () => {
     it('returns dashboard with cards', async () => {
-      const handler = registeredTools.get('get_dashboard')?.[2];
+      const handler = registeredTools.get('get_dashboard')?.handler;
       const result = await handler({ dashboard_id: 1 });
 
       expect(result.isError).toBeFalsy();
@@ -110,7 +110,7 @@ describe('Read Tools Integration', () => {
     });
 
     it('calls Metabase client with correct ID', async () => {
-      const handler = registeredTools.get('get_dashboard')?.[2];
+      const handler = registeredTools.get('get_dashboard')?.handler;
       await handler({ dashboard_id: 42 });
 
       expect(mockClient.getDashboard).toHaveBeenCalledWith(42);
@@ -119,7 +119,7 @@ describe('Read Tools Integration', () => {
 
   describe('list_cards', () => {
     it('returns list of cards', async () => {
-      const handler = registeredTools.get('list_cards')?.[2];
+      const handler = registeredTools.get('list_cards')?.handler;
       const result = await handler({});
 
       expect(result.isError).toBeFalsy();
@@ -131,7 +131,7 @@ describe('Read Tools Integration', () => {
 
   describe('get_card', () => {
     it('returns card details', async () => {
-      const handler = registeredTools.get('get_card')?.[2];
+      const handler = registeredTools.get('get_card')?.handler;
       const result = await handler({ card_id: 1 });
 
       expect(result.isError).toBeFalsy();
@@ -143,7 +143,7 @@ describe('Read Tools Integration', () => {
 
   describe('execute_card', () => {
     it('executes card and returns results', async () => {
-      const handler = registeredTools.get('execute_card')?.[2];
+      const handler = registeredTools.get('execute_card')?.handler;
       const result = await handler({ card_id: 1 });
 
       expect(result.isError).toBeFalsy();
@@ -154,7 +154,7 @@ describe('Read Tools Integration', () => {
     });
 
     it('passes parameters to Metabase', async () => {
-      const handler = registeredTools.get('execute_card')?.[2];
+      const handler = registeredTools.get('execute_card')?.handler;
       await handler({ card_id: 1, parameters: { date: '2024-01-01' } });
 
       expect(mockClient.executeCard).toHaveBeenCalledWith(1, { date: '2024-01-01' });
@@ -163,7 +163,7 @@ describe('Read Tools Integration', () => {
     it('truncates results exceeding maxRows', async () => {
       mockClient.executeCard.mockResolvedValueOnce(largeQueryResult);
 
-      const handler = registeredTools.get('execute_card')?.[2];
+      const handler = registeredTools.get('execute_card')?.handler;
       const result = await handler({ card_id: 1 });
 
       const data = JSON.parse(result.content[0].text);
@@ -174,7 +174,7 @@ describe('Read Tools Integration', () => {
 
   describe('list_databases', () => {
     it('returns list of databases', async () => {
-      const handler = registeredTools.get('list_databases')?.[2];
+      const handler = registeredTools.get('list_databases')?.handler;
       const result = await handler({});
 
       expect(result.isError).toBeFalsy();
@@ -187,7 +187,7 @@ describe('Read Tools Integration', () => {
 
   describe('get_database_schema', () => {
     it('returns database schema', async () => {
-      const handler = registeredTools.get('get_database_schema')?.[2];
+      const handler = registeredTools.get('get_database_schema')?.handler;
       const result = await handler({ database_id: 1 });
 
       expect(result.isError).toBeFalsy();
@@ -197,7 +197,7 @@ describe('Read Tools Integration', () => {
     });
 
     it('caches schema after first call', async () => {
-      const handler = registeredTools.get('get_database_schema')?.[2];
+      const handler = registeredTools.get('get_database_schema')?.handler;
 
       await handler({ database_id: 1 });
       await handler({ database_id: 1 });
@@ -209,7 +209,7 @@ describe('Read Tools Integration', () => {
 
   describe('execute_query', () => {
     it('executes valid SQL query', async () => {
-      const handler = registeredTools.get('execute_query')?.[2];
+      const handler = registeredTools.get('execute_query')?.handler;
       const result = await handler({
         database_id: 1,
         sql: 'SELECT * FROM users LIMIT 10',
@@ -222,7 +222,7 @@ describe('Read Tools Integration', () => {
     });
 
     it('blocks dangerous SQL', async () => {
-      const handler = registeredTools.get('execute_query')?.[2];
+      const handler = registeredTools.get('execute_query')?.handler;
       const result = await handler({
         database_id: 1,
         sql: 'DROP TABLE users',
@@ -234,7 +234,7 @@ describe('Read Tools Integration', () => {
     });
 
     it('blocks SQL injection attempts', async () => {
-      const handler = registeredTools.get('execute_query')?.[2];
+      const handler = registeredTools.get('execute_query')?.handler;
       const result = await handler({
         database_id: 1,
         sql: "SELECT * FROM users; DROP TABLE users;--",
@@ -244,7 +244,7 @@ describe('Read Tools Integration', () => {
     });
 
     it('includes warnings in response', async () => {
-      const handler = registeredTools.get('execute_query')?.[2];
+      const handler = registeredTools.get('execute_query')?.handler;
       const result = await handler({
         database_id: 1,
         sql: 'SELECT * FROM users', // No LIMIT, should warn
@@ -256,7 +256,7 @@ describe('Read Tools Integration', () => {
     });
 
     it('sanitizes SQL before execution', async () => {
-      const handler = registeredTools.get('execute_query')?.[2];
+      const handler = registeredTools.get('execute_query')?.handler;
       await handler({
         database_id: 1,
         sql: '  SELECT    *   FROM   users   LIMIT 10  ',
@@ -276,7 +276,7 @@ describe('Read Tools Integration', () => {
         { id: 1, name: 'Sales', description: null, model: 'dashboard', collection_id: 1, collection_name: 'Analytics' },
       ]);
 
-      const handler = registeredTools.get('search_content')?.[2];
+      const handler = registeredTools.get('search_content')?.handler;
       const result = await handler({ query: 'sales' });
 
       expect(result.isError).toBeFalsy();
@@ -286,7 +286,7 @@ describe('Read Tools Integration', () => {
     });
 
     it('filters by content type', async () => {
-      const handler = registeredTools.get('search_content')?.[2];
+      const handler = registeredTools.get('search_content')?.handler;
       await handler({ query: 'sales', type: 'dashboard' });
 
       expect(mockClient.search).toHaveBeenCalledWith('sales', ['dashboard']);
@@ -295,7 +295,7 @@ describe('Read Tools Integration', () => {
 
   describe('get_collections', () => {
     it('returns list of collections', async () => {
-      const handler = registeredTools.get('get_collections')?.[2];
+      const handler = registeredTools.get('get_collections')?.handler;
       const result = await handler({});
 
       expect(result.isError).toBeFalsy();
@@ -309,7 +309,7 @@ describe('Read Tools Integration', () => {
     it('handles Metabase client errors gracefully', async () => {
       mockClient.getDashboards.mockRejectedValueOnce(new Error('Connection failed'));
 
-      const handler = registeredTools.get('list_dashboards')?.[2];
+      const handler = registeredTools.get('list_dashboards')?.handler;
       const result = await handler({});
 
       expect(result.isError).toBe(true);
@@ -322,7 +322,7 @@ describe('Read Tools Integration', () => {
     it('logs successful operations', async () => {
       const logSpy = vi.spyOn(context.auditLogger, 'logSuccess');
 
-      const handler = registeredTools.get('list_dashboards')?.[2];
+      const handler = registeredTools.get('list_dashboards')?.handler;
       await handler({});
 
       expect(logSpy).toHaveBeenCalledWith('list_dashboards', expect.any(Object));
@@ -332,7 +332,7 @@ describe('Read Tools Integration', () => {
       const logSpy = vi.spyOn(context.auditLogger, 'logFailure');
       mockClient.getDashboards.mockRejectedValueOnce(new Error('Failed'));
 
-      const handler = registeredTools.get('list_dashboards')?.[2];
+      const handler = registeredTools.get('list_dashboards')?.handler;
       await handler({});
 
       expect(logSpy).toHaveBeenCalled();
@@ -341,7 +341,7 @@ describe('Read Tools Integration', () => {
     it('logs blocked SQL queries', async () => {
       const logSpy = vi.spyOn(context.auditLogger, 'logBlocked');
 
-      const handler = registeredTools.get('execute_query')?.[2];
+      const handler = registeredTools.get('execute_query')?.handler;
       await handler({ database_id: 1, sql: 'DROP TABLE users' });
 
       expect(logSpy).toHaveBeenCalledWith('execute_query', expect.any(String), expect.any(Object));

--- a/tests/integration/write-tools.test.ts
+++ b/tests/integration/write-tools.test.ts
@@ -53,7 +53,7 @@ describe('Write Tools Integration', () => {
     registeredTools = new Map();
     const originalTool = server.tool.bind(server);
     vi.spyOn(server, 'tool').mockImplementation((name: string, ...args: any[]) => {
-      registeredTools.set(name, args);
+      const handler = args[args.length - 1]; registeredTools.set(name, { args, handler });
       return originalTool(name, ...args);
     });
 
@@ -66,7 +66,7 @@ describe('Write Tools Integration', () => {
     });
 
     it('creates a new card with valid SQL', async () => {
-      const handler = registeredTools.get('create_card')?.[2];
+      const handler = registeredTools.get('create_card')?.handler;
       const result = await handler({
         name: 'New Card',
         database_id: 1,
@@ -81,7 +81,7 @@ describe('Write Tools Integration', () => {
     });
 
     it('validates SQL before creating card', async () => {
-      const handler = registeredTools.get('create_card')?.[2];
+      const handler = registeredTools.get('create_card')?.handler;
       const result = await handler({
         name: 'Bad Card',
         database_id: 1,
@@ -94,7 +94,7 @@ describe('Write Tools Integration', () => {
     });
 
     it('passes all parameters to Metabase client', async () => {
-      const handler = registeredTools.get('create_card')?.[2];
+      const handler = registeredTools.get('create_card')?.handler;
       await handler({
         name: 'Test Card',
         database_id: 1,
@@ -117,7 +117,7 @@ describe('Write Tools Integration', () => {
 
   describe('update_card', () => {
     it('updates card name', async () => {
-      const handler = registeredTools.get('update_card')?.[2];
+      const handler = registeredTools.get('update_card')?.handler;
       const result = await handler({
         card_id: 1,
         name: 'Updated Name',
@@ -128,7 +128,7 @@ describe('Write Tools Integration', () => {
     });
 
     it('updates card SQL with validation', async () => {
-      const handler = registeredTools.get('update_card')?.[2];
+      const handler = registeredTools.get('update_card')?.handler;
       await handler({
         card_id: 1,
         sql: 'SELECT * FROM orders',
@@ -147,7 +147,7 @@ describe('Write Tools Integration', () => {
     });
 
     it('rejects invalid SQL updates', async () => {
-      const handler = registeredTools.get('update_card')?.[2];
+      const handler = registeredTools.get('update_card')?.handler;
       const result = await handler({
         card_id: 1,
         sql: 'DELETE FROM users',
@@ -158,7 +158,7 @@ describe('Write Tools Integration', () => {
     });
 
     it('updates multiple fields at once', async () => {
-      const handler = registeredTools.get('update_card')?.[2];
+      const handler = registeredTools.get('update_card')?.handler;
       await handler({
         card_id: 1,
         name: 'New Name',
@@ -176,7 +176,7 @@ describe('Write Tools Integration', () => {
 
   describe('delete_card', () => {
     it('deletes/archives a card', async () => {
-      const handler = registeredTools.get('delete_card')?.[2];
+      const handler = registeredTools.get('delete_card')?.handler;
       const result = await handler({ card_id: 1 });
 
       expect(result.isError).toBeFalsy();
@@ -188,7 +188,7 @@ describe('Write Tools Integration', () => {
 
   describe('create_dashboard', () => {
     it('creates a new dashboard', async () => {
-      const handler = registeredTools.get('create_dashboard')?.[2];
+      const handler = registeredTools.get('create_dashboard')?.handler;
       const result = await handler({
         name: 'New Dashboard',
         description: 'Dashboard description',
@@ -201,7 +201,7 @@ describe('Write Tools Integration', () => {
     });
 
     it('passes collection_id when provided', async () => {
-      const handler = registeredTools.get('create_dashboard')?.[2];
+      const handler = registeredTools.get('create_dashboard')?.handler;
       await handler({
         name: 'New Dashboard',
         collection_id: 5,
@@ -217,7 +217,7 @@ describe('Write Tools Integration', () => {
 
   describe('update_dashboard', () => {
     it('updates dashboard properties', async () => {
-      const handler = registeredTools.get('update_dashboard')?.[2];
+      const handler = registeredTools.get('update_dashboard')?.handler;
       const result = await handler({
         dashboard_id: 1,
         name: 'Updated Dashboard',
@@ -234,7 +234,7 @@ describe('Write Tools Integration', () => {
 
   describe('delete_dashboard', () => {
     it('deletes/archives a dashboard', async () => {
-      const handler = registeredTools.get('delete_dashboard')?.[2];
+      const handler = registeredTools.get('delete_dashboard')?.handler;
       const result = await handler({ dashboard_id: 1 });
 
       expect(result.isError).toBeFalsy();
@@ -244,7 +244,7 @@ describe('Write Tools Integration', () => {
 
   describe('add_card_to_dashboard', () => {
     it('adds card to dashboard with default position', async () => {
-      const handler = registeredTools.get('add_card_to_dashboard')?.[2];
+      const handler = registeredTools.get('add_card_to_dashboard')?.handler;
       const result = await handler({
         dashboard_id: 1,
         card_id: 5,
@@ -260,7 +260,7 @@ describe('Write Tools Integration', () => {
     });
 
     it('adds card with custom position and size', async () => {
-      const handler = registeredTools.get('add_card_to_dashboard')?.[2];
+      const handler = registeredTools.get('add_card_to_dashboard')?.handler;
       await handler({
         dashboard_id: 1,
         card_id: 5,
@@ -281,7 +281,7 @@ describe('Write Tools Integration', () => {
 
   describe('remove_card_from_dashboard', () => {
     it('removes card from dashboard', async () => {
-      const handler = registeredTools.get('remove_card_from_dashboard')?.[2];
+      const handler = registeredTools.get('remove_card_from_dashboard')?.handler;
       const result = await handler({
         dashboard_id: 1,
         dashcard_id: 10,
@@ -294,7 +294,7 @@ describe('Write Tools Integration', () => {
 
   describe('create_collection', () => {
     it('creates a new collection', async () => {
-      const handler = registeredTools.get('create_collection')?.[2];
+      const handler = registeredTools.get('create_collection')?.handler;
       const result = await handler({
         name: 'New Collection',
         description: 'Collection description',
@@ -313,7 +313,7 @@ describe('Write Tools Integration', () => {
     });
 
     it('creates nested collection with parent_id', async () => {
-      const handler = registeredTools.get('create_collection')?.[2];
+      const handler = registeredTools.get('create_collection')?.handler;
       await handler({
         name: 'Sub Collection',
         parent_id: 1,
@@ -329,7 +329,7 @@ describe('Write Tools Integration', () => {
 
   describe('move_to_collection', () => {
     it('moves card to collection', async () => {
-      const handler = registeredTools.get('move_to_collection')?.[2];
+      const handler = registeredTools.get('move_to_collection')?.handler;
       const result = await handler({
         item_type: 'card',
         item_id: 1,
@@ -341,7 +341,7 @@ describe('Write Tools Integration', () => {
     });
 
     it('moves dashboard to collection', async () => {
-      const handler = registeredTools.get('move_to_collection')?.[2];
+      const handler = registeredTools.get('move_to_collection')?.handler;
       await handler({
         item_type: 'dashboard',
         item_id: 1,
@@ -354,7 +354,7 @@ describe('Write Tools Integration', () => {
 
   describe('rate limiting', () => {
     it('enforces write rate limits', async () => {
-      const handler = registeredTools.get('create_card')?.[2];
+      const handler = registeredTools.get('create_card')?.handler;
 
       // Exhaust the write rate limit (30 per minute by default)
       for (let i = 0; i < 30; i++) {
@@ -376,7 +376,7 @@ describe('Write Tools Integration', () => {
     it('handles Metabase API errors', async () => {
       mockClient.createCard.mockRejectedValueOnce(new Error('API Error'));
 
-      const handler = registeredTools.get('create_card')?.[2];
+      const handler = registeredTools.get('create_card')?.handler;
       const result = await handler({
         name: 'Test',
         database_id: 1,
@@ -394,7 +394,7 @@ describe('Write Tools Integration', () => {
     it('logs successful write operations', async () => {
       const logSpy = vi.spyOn(context.auditLogger, 'logSuccess');
 
-      const handler = registeredTools.get('create_dashboard')?.[2];
+      const handler = registeredTools.get('create_dashboard')?.handler;
       await handler({ name: 'Test Dashboard' });
 
       expect(logSpy).toHaveBeenCalledWith('create_dashboard', expect.any(Object));
@@ -404,7 +404,7 @@ describe('Write Tools Integration', () => {
       const logSpy = vi.spyOn(context.auditLogger, 'logFailure');
       mockClient.createDashboard.mockRejectedValueOnce(new Error('Failed'));
 
-      const handler = registeredTools.get('create_dashboard')?.[2];
+      const handler = registeredTools.get('create_dashboard')?.handler;
       await handler({ name: 'Test Dashboard' });
 
       expect(logSpy).toHaveBeenCalled();
@@ -413,7 +413,7 @@ describe('Write Tools Integration', () => {
     it('logs blocked SQL in write operations', async () => {
       const logSpy = vi.spyOn(context.auditLogger, 'logBlocked');
 
-      const handler = registeredTools.get('create_card')?.[2];
+      const handler = registeredTools.get('create_card')?.handler;
       await handler({
         name: 'Bad Card',
         database_id: 1,


### PR DESCRIPTION
## Summary
Brings the repo into full compliance with [Anthropic's MCP Directory Policy](https://support.claude.com/en/articles/11697096-anthropic-mcp-directory-policy) ahead of submission.

## Changes

### Tool Annotations (Policy #17 — hard requirement)
All 28 tools now declare annotations per MCP spec:
- \`title\` (human-readable)
- \`readOnlyHint\` (for read/NLQ/insight tools)
- \`destructiveHint\` (for write tools — \`true\` for updates/deletes, \`false\` for creates)
- \`idempotentHint\` (where applicable)
- \`openWorldHint\` (all tools touch external services)

Updated: \`src/tools/read-tools.ts\`, \`write-tools.ts\`, \`nlq-tools.ts\`, \`insight-tools.ts\`

### Privacy Policy in README (Policy #20)
New \`## Privacy Policy\` section covering: what's collected, what's transmitted, retention, third-party policies, security reporting

### Troubleshooting in README (Policy #22)
New \`## Troubleshooting\` section covering common errors: connection/auth, SQL guardrails, rate limits, NLQ setup, Claude Desktop issues

### Support section in README (Policy #21)
New \`## Support\` section with GitHub Issues, security advisories, response time SLA

### Test harness update
Made test integration harness robust to tool signature changes — finds the handler by identifying the last-arg function instead of indexing by position. Previously broke when annotations were added.

## Verification
- ✅ All 363 tests pass
- ✅ Type check passes
- ✅ Every tool has \`readOnlyHint\` or \`destructiveHint\` (policy #17)
- ✅ Privacy policy present in README (policy #20) AND manifest (already existed in mcpb/manifest.json)
- ✅ README covers: description, features, install, config, examples (5), privacy, troubleshooting, support

## Remaining before directory submission (not in this PR)
- [ ] Set up a read-only Metabase test account with sample data for Anthropic reviewers
- [ ] Bump to v1.1.1 with these policy-compliance changes
- [ ] Submit the Google Form

## Policy checklist
- [x] #17 Tool annotations on every tool
- [x] #20 Privacy policy in README + manifest
- [x] #21 Verified support channels
- [x] #22 Troubleshooting documentation
- [x] #24 ≥3 usage examples (have 5)
- [x] #15 Tool names ≤64 chars