### PR TITLE
Add glama.json for Glama MCP registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CI](https://github.com/1luvc0d3/metabase-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/1luvc0d3/metabase-mcp/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Node](https://img.shields.io/node/v/@ai-1luvc0d3/metabase-mcp.svg)](https://nodejs.org)
+[![metabase-mcp MCP server](https://glama.ai/mcp/servers/1luvc0d3/metabase-mcp/badges/card.svg)](https://glama.ai/mcp/servers/1luvc0d3/metabase-mcp)
 
 The most feature-rich [MCP](https://modelcontextprotocol.io/) server for [Metabase](https://www.metabase.com/). Ask questions about your data in plain English, manage dashboards, and run SQL queries -- all through Claude.
 

--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["1luvc0d3"]
+}


### PR DESCRIPTION
Adds `glama.json` at repo root so the [Glama MCP registry](https://glama.ai/mcp/servers/1luvc0d3/metabase-mcp) can identify maintainers and validate the server.

Required to improve the Glama quality score, which is in turn a prerequisite for merging [punkpeye/awesome-mcp-servers#4531](https://github.com/punkpeye/awesome-mcp-servers/pull/4531).

## Test plan
- [ ] After merge, verify Glama re-crawls and `Missing or invalid glama.json` flips to green on the scoring page.