### PR TITLE
Add CodeAct-inspired batch/workflow tools, default compact responses (v1.3.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,11 +66,13 @@ API key authentication via `METABASE_API_KEY`. The key is passed as `X-API-Key` 
 - **src/client/types.ts** - Metabase API types and config interfaces
 - **src/client/llm-service.ts** - Anthropic Claude API integration with token budgeting (daily/monthly limits)
 
-### Tool Categories (28 total tools)
+### Tool Categories (30 total tools)
 
 | Category | File | Tools | Description |
 |----------|------|-------|-------------|
 | Read-Only | `src/tools/read-tools.ts` | 10 | Dashboard, card, database, collection queries |
+| Batch | `src/tools/batch-tools.ts` | 1 | Parallel execution of multiple read operations |
+| Workflow | `src/tools/workflow-tools.ts` | 1 | Composable multi-step pipelines with output chaining |
 | DML/Write | `src/tools/write-tools.ts` | 10 | Create/update/delete cards, dashboards, collections |
 | NLQ | `src/tools/nlq-tools.ts` | 4 | Natural language to SQL conversion |
 | Insights | `src/tools/insight-tools.ts` | 4 | Automated data analysis and trends |
@@ -101,9 +103,9 @@ API key authentication via `METABASE_API_KEY`. The key is passed as `X-API-Key` 
 
 The `MCP_MODE` environment variable controls which tools are available:
 
-- **read** - 10 read-only tools + NLQ (if Anthropic key set)
-- **write** - 20 tools (read + DML) + NLQ
-- **full** - All 28 tools including insights
+- **read** - 12 tools (10 read-only + batch + workflow) + NLQ (if Anthropic key set)
+- **write** - 22 tools (read + batch + workflow + DML) + NLQ
+- **full** - All 30 tools including insights
 
 ## Test Structure
 
@@ -122,6 +124,8 @@ tests/
 └── integration/
     ├── read-tools.test.ts
     ├── write-tools.test.ts
+    ├── batch-tools.test.ts
+    ├── workflow-tools.test.ts
     └── nlq-tools.test.ts
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ai-1luvc0d3/metabase-mcp",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "MCP server connecting Claude to Metabase for data analysis",
   "type": "module",
   "main": "dist/index.js",

--- a/src/tools/batch-tools.ts
+++ b/src/tools/batch-tools.ts
@@ -1,0 +1,231 @@
+/**
+ * Batch Tools
+ * Tools for executing multiple operations in a single call to reduce round trips
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { ToolContext } from './types.js';
+import { createCompactTextResponse, createErrorResponse } from './types.js';
+import { formatQueryResult, formatSchemaResult } from '../utils/response-formatter.js';
+
+const MAX_OPERATIONS = 20;
+
+const operationSchema = z.discriminatedUnion('tool', [
+  z.object({
+    tool: z.literal('get_dashboard'),
+    args: z.object({ dashboard_id: z.number() }),
+  }),
+  z.object({
+    tool: z.literal('get_card'),
+    args: z.object({ card_id: z.number() }),
+  }),
+  z.object({
+    tool: z.literal('execute_card'),
+    args: z.object({
+      card_id: z.number(),
+      parameters: z.record(z.unknown()).optional(),
+      limit: z.number().min(1).max(10000).optional(),
+    }),
+  }),
+  z.object({
+    tool: z.literal('get_database_schema'),
+    args: z.object({
+      database_id: z.number(),
+      detail: z.enum(['full', 'tables_only']).optional(),
+      tables: z.array(z.string()).optional(),
+    }),
+  }),
+  z.object({
+    tool: z.literal('execute_query'),
+    args: z.object({
+      database_id: z.number(),
+      sql: z.string(),
+      limit: z.number().min(1).max(10000).optional(),
+    }),
+  }),
+  z.object({
+    tool: z.literal('search_content'),
+    args: z.object({
+      query: z.string(),
+      type: z.enum(['card', 'dashboard', 'collection', 'database', 'table']).optional(),
+    }),
+  }),
+  z.object({
+    tool: z.literal('list_dashboards'),
+    args: z.object({}).optional(),
+  }),
+  z.object({
+    tool: z.literal('list_databases'),
+    args: z.object({}).optional(),
+  }),
+  z.object({
+    tool: z.literal('list_cards'),
+    args: z.object({
+      collection_id: z.number().optional(),
+      limit: z.number().min(1).max(100).optional(),
+    }).optional(),
+  }),
+]);
+
+type Operation = z.infer<typeof operationSchema>;
+
+async function executeOperation(
+  op: Operation,
+  ctx: ToolContext,
+): Promise<{ tool: string; success: boolean; result?: unknown; error?: string }> {
+  try {
+    switch (op.tool) {
+      case 'get_dashboard': {
+        const dashboard = await ctx.metabaseClient.getDashboard(op.args.dashboard_id);
+        return { tool: op.tool, success: true, result: dashboard };
+      }
+      case 'get_card': {
+        const card = await ctx.metabaseClient.getCard(op.args.card_id);
+        return { tool: op.tool, success: true, result: card };
+      }
+      case 'execute_card': {
+        const result = await ctx.metabaseClient.executeCard(op.args.card_id, op.args.parameters);
+        const formatted = formatQueryResult(
+          result.data.cols,
+          result.data.rows,
+          result.row_count,
+          { format: 'compact', limit: op.args.limit ?? ctx.config.metabase.maxRows, offset: 0 }
+        );
+        return { tool: op.tool, success: true, result: formatted };
+      }
+      case 'get_database_schema': {
+        const schema = await ctx.schemaManager.getSchema(op.args.database_id);
+        const formatted = formatSchemaResult(schema, {
+          detail: op.args.detail,
+          format: 'compact',
+          tables: op.args.tables,
+        });
+        return { tool: op.tool, success: true, result: formatted };
+      }
+      case 'execute_query': {
+        const validation = ctx.sqlGuardrails.validate(op.args.sql);
+        if (!validation.valid) {
+          return { tool: op.tool, success: false, error: `SQL validation failed: ${validation.errors.join(', ')}` };
+        }
+        const queryResult = await ctx.metabaseClient.executeQuery(op.args.database_id, validation.sanitizedSQL);
+        const formatted = formatQueryResult(
+          queryResult.data.cols,
+          queryResult.data.rows,
+          queryResult.row_count,
+          { format: 'compact', limit: op.args.limit ?? ctx.config.metabase.maxRows, offset: 0 }
+        );
+        return { tool: op.tool, success: true, result: formatted };
+      }
+      case 'search_content': {
+        const results = await ctx.metabaseClient.search(op.args.query, op.args.type ? [op.args.type] : undefined);
+        return {
+          tool: op.tool,
+          success: true,
+          result: {
+            count: results.length,
+            results: results.map(r => ({
+              id: r.id, name: r.name, model: r.model,
+              collection_id: r.collection_id,
+            })),
+          },
+        };
+      }
+      case 'list_dashboards': {
+        const dashboards = await ctx.metabaseClient.getDashboards();
+        return {
+          tool: op.tool,
+          success: true,
+          result: {
+            count: dashboards.length,
+            dashboards: dashboards.map(d => ({ id: d.id, name: d.name, collection_id: d.collection_id })),
+          },
+        };
+      }
+      case 'list_databases': {
+        const databases = await ctx.metabaseClient.getDatabases();
+        return {
+          tool: op.tool,
+          success: true,
+          result: {
+            count: databases.length,
+            databases: databases.map(d => ({ id: d.id, name: d.name, engine: d.engine })),
+          },
+        };
+      }
+      case 'list_cards': {
+        let cards = await ctx.metabaseClient.getCards();
+        if (op.args?.collection_id !== undefined) {
+          cards = cards.filter(c => c.collection_id === op.args!.collection_id);
+        }
+        const limit = op.args?.limit ?? 100;
+        cards = cards.slice(0, limit);
+        return {
+          tool: op.tool,
+          success: true,
+          result: {
+            count: cards.length,
+            cards: cards.map(c => ({ id: c.id, name: c.name, display: c.display, collection_id: c.collection_id })),
+          },
+        };
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return { tool: op.tool, success: false, error: message };
+  }
+}
+
+export function registerBatchTools(server: McpServer, ctx: ToolContext): void {
+  server.tool(
+    'batch_execute',
+    `Execute multiple read operations in a single call. Supports up to ${MAX_OPERATIONS} operations run in parallel. Supported tools: get_dashboard, get_card, execute_card, get_database_schema, execute_query, search_content, list_dashboards, list_databases, list_cards.`,
+    {
+      operations: z.array(operationSchema).min(1).max(MAX_OPERATIONS)
+        .describe('Array of operations to execute in parallel'),
+    },
+    { title: 'Batch Execute', readOnlyHint: true, openWorldHint: true },
+    async ({ operations }) => {
+      try {
+        ctx.rateLimiter.checkLimit('read');
+
+        const startTime = Date.now();
+        const results = await Promise.allSettled(
+          operations.map(op => executeOperation(op, ctx))
+        );
+
+        const responses = results.map((r, i) => {
+          if (r.status === 'fulfilled') {
+            return r.value;
+          }
+          return {
+            tool: operations[i].tool,
+            success: false,
+            error: r.reason instanceof Error ? r.reason.message : String(r.reason),
+          };
+        });
+
+        const succeeded = responses.filter(r => r.success).length;
+        const failed = responses.filter(r => !r.success).length;
+
+        ctx.auditLogger.logSuccess('batch_execute', {
+          operationCount: operations.length,
+          succeeded,
+          failed,
+          durationMs: Date.now() - startTime,
+        });
+
+        return createCompactTextResponse({
+          total: operations.length,
+          succeeded,
+          failed,
+          duration_ms: Date.now() - startTime,
+          results: responses,
+        });
+      } catch (error) {
+        ctx.auditLogger.logFailure('batch_execute', error as Error);
+        return createErrorResponse(error as Error);
+      }
+    }
+  );
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -9,6 +9,8 @@ import { registerReadTools } from './read-tools.js';
 import { registerWriteTools } from './write-tools.js';
 import { registerNLQTools } from './nlq-tools.js';
 import { registerInsightTools } from './insight-tools.js';
+import { registerBatchTools } from './batch-tools.js';
+import { registerWorkflowTools } from './workflow-tools.js';
 
 export async function registerTools(
   server: McpServer,
@@ -16,9 +18,12 @@ export async function registerTools(
 ): Promise<void> {
   const { config, logger } = context;
 
-  // Always register read tools
+  // Always register read tools, batch tools, and workflow tools
   registerReadTools(server, context);
+  registerBatchTools(server, context);
+  registerWorkflowTools(server, context);
   logger.info('Registered read-only tools');
+  logger.info('Registered batch and workflow tools');
 
   // Register write tools if mode allows
   if (config.mode === 'write' || config.mode === 'full') {
@@ -41,6 +46,8 @@ export async function registerTools(
   // Log summary
   const toolCounts = {
     read: 10,
+    batch: 1,
+    workflow: 1,
     write: config.mode === 'write' || config.mode === 'full' ? 10 : 0,
     nlq: context.llmService ? 4 : 0,
     insight: config.mode === 'full' && context.llmService ? 4 : 0,

--- a/src/tools/insight-tools.ts
+++ b/src/tools/insight-tools.ts
@@ -27,7 +27,7 @@ export function registerInsightTools(server: McpServer, ctx: ToolContext): void 
       question: z.string().describe('Natural language question about your data'),
       database_id: z.number().describe('Database ID to query'),
       tables: z.array(z.string()).optional().describe('Specific tables to consider'),
-      format: z.enum(['default', 'compact']).optional().describe('Response format. "compact" reduces token usage'),
+      format: z.enum(['default', 'compact']).optional().describe('Response format (default: compact). Use "default" for pretty-printed output'),
     },
     { title: 'Ask Data Question', readOnlyHint: true, openWorldHint: true },
     async ({ question, database_id, tables, format }) => {
@@ -76,7 +76,7 @@ export function registerInsightTools(server: McpServer, ctx: ToolContext): void 
           queryDurationMs: queryDuration,
         });
 
-        const sampleSize = format === 'compact' ? 5 : 10;
+        const sampleSize = format === 'default' ? 10 : 5;
         const responseData = {
           success: true,
           answer: insights.summary,
@@ -91,9 +91,9 @@ export function registerInsightTools(server: McpServer, ctx: ToolContext): void 
           query_time_ms: queryDuration,
         };
 
-        return format === 'compact'
-          ? createCompactTextResponse(responseData)
-          : createTextResponse(responseData);
+        return format === 'default'
+          ? createTextResponse(responseData)
+          : createCompactTextResponse(responseData);
       } catch (error) {
         ctx.auditLogger.logFailure('ask_data', error as Error, { question, database_id });
         return createErrorResponse(error as Error);
@@ -109,7 +109,7 @@ export function registerInsightTools(server: McpServer, ctx: ToolContext): void 
     'Auto-generate insights from an existing card/question',
     {
       card_id: z.number().describe('Card ID to analyze'),
-      format: z.enum(['default', 'compact']).optional().describe('Response format. "compact" reduces token usage'),
+      format: z.enum(['default', 'compact']).optional().describe('Response format (default: compact). Use "default" for pretty-printed output'),
     },
     { title: 'Generate Insights', readOnlyHint: true, openWorldHint: true },
     async ({ card_id, format }) => {
@@ -149,9 +149,9 @@ export function registerInsightTools(server: McpServer, ctx: ToolContext): void 
           query_time_ms: queryDuration,
         };
 
-        return format === 'compact'
-          ? createCompactTextResponse(responseData)
-          : createTextResponse(responseData);
+        return format === 'default'
+          ? createTextResponse(responseData)
+          : createCompactTextResponse(responseData);
       } catch (error) {
         ctx.auditLogger.logFailure('generate_insights', error as Error, { card_id });
         return createErrorResponse(error as Error);
@@ -169,7 +169,7 @@ export function registerInsightTools(server: McpServer, ctx: ToolContext): void 
       question: z.string().describe('Comparison question (e.g., "Compare sales in Q1 vs Q2")'),
       database_id: z.number().describe('Database ID'),
       tables: z.array(z.string()).optional().describe('Specific tables to use'),
-      format: z.enum(['default', 'compact']).optional().describe('Response format. "compact" reduces token usage'),
+      format: z.enum(['default', 'compact']).optional().describe('Response format (default: compact). Use "default" for pretty-printed output'),
     },
     { title: 'Compare Metrics', readOnlyHint: true, openWorldHint: true },
     async ({ question, database_id, tables, format }) => {
@@ -226,9 +226,9 @@ export function registerInsightTools(server: McpServer, ctx: ToolContext): void 
           sql: validation.sanitizedSQL,
         };
 
-        return format === 'compact'
-          ? createCompactTextResponse(responseData)
-          : createTextResponse(responseData);
+        return format === 'default'
+          ? createTextResponse(responseData)
+          : createCompactTextResponse(responseData);
       } catch (error) {
         ctx.auditLogger.logFailure('compare_metrics', error as Error, { question, database_id });
         return createErrorResponse(error as Error);
@@ -246,7 +246,7 @@ export function registerInsightTools(server: McpServer, ctx: ToolContext): void 
       question: z.string().describe('Question about trends (e.g., "What are the sales trends over the past year?")'),
       database_id: z.number().describe('Database ID'),
       tables: z.array(z.string()).optional().describe('Specific tables to use'),
-      format: z.enum(['default', 'compact']).optional().describe('Response format. "compact" reduces token usage'),
+      format: z.enum(['default', 'compact']).optional().describe('Response format (default: compact). Use "default" for pretty-printed output'),
     },
     { title: 'Trend Analysis', readOnlyHint: true, openWorldHint: true },
     async ({ question, database_id, tables, format }) => {
@@ -304,9 +304,9 @@ export function registerInsightTools(server: McpServer, ctx: ToolContext): void 
           sql: validation.sanitizedSQL,
         };
 
-        return format === 'compact'
-          ? createCompactTextResponse(responseData)
-          : createTextResponse(responseData);
+        return format === 'default'
+          ? createTextResponse(responseData)
+          : createCompactTextResponse(responseData);
       } catch (error) {
         ctx.auditLogger.logFailure('trend_analysis', error as Error, { question, database_id });
         return createErrorResponse(error as Error);

--- a/src/tools/nlq-tools.ts
+++ b/src/tools/nlq-tools.ts
@@ -6,7 +6,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ToolContext } from './types.js';
-import { createTextResponse, createErrorResponse } from './types.js';
+import { createTextResponse, createErrorResponse, createCompactTextResponse } from './types.js';
 
 export function registerNLQTools(server: McpServer, ctx: ToolContext): void {
   // Ensure LLM service is available
@@ -81,7 +81,7 @@ export function registerNLQTools(server: McpServer, ctx: ToolContext): void {
           tablesUsed: schema.tables.length,
         });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           success: true,
           sql: validation.sanitizedSQL,
           explanation: result.explanation,
@@ -111,7 +111,7 @@ export function registerNLQTools(server: McpServer, ctx: ToolContext): void {
         const explanation = await llmService.explainSQL(sql);
         ctx.auditLogger.logSuccess('explain_sql', { sqlLength: sql.length });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           sql,
           explanation,
         });
@@ -156,7 +156,7 @@ export function registerNLQTools(server: McpServer, ctx: ToolContext): void {
         const optimization = await llmService.optimizeSQL(sql, executionPlan);
         ctx.auditLogger.logSuccess('optimize_sql', { sqlLength: sql.length });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           original_sql: sql,
           suggestions: optimization.suggestions,
           optimized_sql: optimization.optimizedSQL,
@@ -189,7 +189,7 @@ export function registerNLQTools(server: McpServer, ctx: ToolContext): void {
           warningCount: validation.warnings.length,
         });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           valid: validation.valid,
           errors: validation.errors,
           warnings: validation.warnings,

--- a/src/tools/read-tools.ts
+++ b/src/tools/read-tools.ts
@@ -25,7 +25,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
         const dashboards = await ctx.metabaseClient.getDashboards();
         ctx.auditLogger.logSuccess('list_dashboards', { count: dashboards.length });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           count: dashboards.length,
           dashboards: dashboards.map(d => ({
             id: d.id,
@@ -58,7 +58,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
         const dashboard = await ctx.metabaseClient.getDashboard(dashboard_id);
         ctx.auditLogger.logSuccess('get_dashboard', { dashboard_id });
 
-        return createTextResponse(dashboard);
+        return createCompactTextResponse(dashboard);
       } catch (error) {
         ctx.auditLogger.logFailure('get_dashboard', error as Error, { dashboard_id });
         return createErrorResponse(error as Error);
@@ -91,7 +91,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
         cards = cards.slice(0, maxCards);
         ctx.auditLogger.logSuccess('list_cards', { count: cards.length });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           count: cards.length,
           ...(truncated ? { truncated: true, message: `Showing first ${maxCards} of many cards. Use search_content or filter by collection_id for better results.` } : {}),
           cards: cards.map(c => ({
@@ -127,7 +127,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
         const card = await ctx.metabaseClient.getCard(card_id);
         ctx.auditLogger.logSuccess('get_card', { card_id });
 
-        return createTextResponse(card);
+        return createCompactTextResponse(card);
       } catch (error) {
         ctx.auditLogger.logFailure('get_card', error as Error, { card_id });
         return createErrorResponse(error as Error);
@@ -145,7 +145,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
       card_id: z.number().describe('Card ID to execute'),
       parameters: z.record(z.unknown()).optional().describe('Optional parameters for parameterized queries'),
       fields: z.array(z.string()).optional().describe('Column names to include in results (default: all)'),
-      format: z.enum(['default', 'compact']).optional().describe('Response format. "compact" reduces token usage by ~50%'),
+      format: z.enum(['default', 'compact']).optional().describe('Response format (default: compact). Use "default" for pretty-printed output'),
       limit: z.number().min(1).max(10000).optional().describe('Max rows to return (default: server maxRows setting)'),
       offset: z.number().min(0).optional().describe('Row offset for pagination'),
     },
@@ -169,7 +169,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
           result.row_count,
           {
             fields,
-            format,
+            format: format ?? 'compact',
             limit: limit ?? ctx.config.metabase.maxRows,
             offset: offset ?? 0,
           }
@@ -180,9 +180,9 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
           execution_time_ms: duration,
         };
 
-        return format === 'compact'
-          ? createCompactTextResponse(response)
-          : createTextResponse(response);
+        return format === 'default'
+          ? createTextResponse(response)
+          : createCompactTextResponse(response);
       } catch (error) {
         ctx.auditLogger.logFailure('execute_card', error as Error, { card_id });
         return createErrorResponse(error as Error);
@@ -204,7 +204,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
         const databases = await ctx.metabaseClient.getDatabases();
         ctx.auditLogger.logSuccess('list_databases', { count: databases.length });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           count: databases.length,
           databases: databases.map(d => ({
             id: d.id,
@@ -230,7 +230,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
     {
       database_id: z.number().describe('Database ID'),
       detail: z.enum(['full', 'tables_only']).optional().describe('Level of detail. "tables_only" returns table names without columns'),
-      format: z.enum(['default', 'compact']).optional().describe('Response format. "compact" reduces token usage'),
+      format: z.enum(['default', 'compact']).optional().describe('Response format (default: compact). Use "default" for pretty-printed output'),
       tables: z.array(z.string()).optional().describe('Filter to specific table names'),
     },
     { title: 'Get Database Schema', readOnlyHint: true, idempotentHint: true, openWorldHint: true },
@@ -243,10 +243,10 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
           tableCount: schema.tables.length,
         });
 
-        const formatted = formatSchemaResult(schema, { detail, format, tables });
-        return format === 'compact'
-          ? createCompactTextResponse(formatted)
-          : createTextResponse(formatted);
+        const formatted = formatSchemaResult(schema, { detail, format: format ?? 'compact', tables });
+        return format === 'default'
+          ? createTextResponse(formatted)
+          : createCompactTextResponse(formatted);
       } catch (error) {
         ctx.auditLogger.logFailure('get_database_schema', error as Error, { database_id });
         return createErrorResponse(error as Error);
@@ -264,7 +264,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
       database_id: z.number().describe('Database ID to query'),
       sql: z.string().describe('SQL query (SELECT statements only)'),
       fields: z.array(z.string()).optional().describe('Column names to include in results (default: all)'),
-      format: z.enum(['default', 'compact']).optional().describe('Response format. "compact" reduces token usage by ~50%'),
+      format: z.enum(['default', 'compact']).optional().describe('Response format (default: compact). Use "default" for pretty-printed output'),
       limit: z.number().min(1).max(10000).optional().describe('Max rows to return (default: server maxRows setting)'),
       offset: z.number().min(0).optional().describe('Row offset for pagination'),
     },
@@ -301,7 +301,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
           result.row_count,
           {
             fields,
-            format,
+            format: format ?? 'compact',
             limit: limit ?? ctx.config.metabase.maxRows,
             offset: offset ?? 0,
           }
@@ -313,9 +313,9 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
           warnings: validation.warnings,
         };
 
-        return format === 'compact'
-          ? createCompactTextResponse(response)
-          : createTextResponse(response);
+        return format === 'default'
+          ? createTextResponse(response)
+          : createCompactTextResponse(response);
       } catch (error) {
         if (error instanceof SQLValidationError) {
           return createErrorResponse(error);
@@ -348,7 +348,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
           resultCount: results.length,
         });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           count: results.length,
           results: results.map(r => ({
             id: r.id,
@@ -380,7 +380,7 @@ export function registerReadTools(server: McpServer, ctx: ToolContext): void {
         const collections = await ctx.metabaseClient.getCollections();
         ctx.auditLogger.logSuccess('get_collections', { count: collections.length });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           count: collections.length,
           collections: collections.map(c => ({
             id: c.id,

--- a/src/tools/workflow-tools.ts
+++ b/src/tools/workflow-tools.ts
@@ -1,0 +1,288 @@
+/**
+ * Workflow Tools
+ * CodeAct-inspired composable pipelines for multi-step operations.
+ * Eliminates multi-turn round trips by chaining tools in a single call.
+ */
+
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { ToolContext } from './types.js';
+import { createCompactTextResponse, createErrorResponse } from './types.js';
+import { formatQueryResult, formatSchemaResult } from '../utils/response-formatter.js';
+import { SQLValidationError } from '../utils/errors.js';
+
+const MAX_STEPS = 10;
+
+const stepSchema = z.object({
+  name: z.string().describe('Unique step name for referencing results (e.g. "find_dashboards")'),
+  tool: z.enum([
+    'list_dashboards', 'get_dashboard', 'list_cards', 'get_card',
+    'execute_card', 'list_databases', 'get_database_schema',
+    'execute_query', 'search_content', 'get_collections',
+  ]).describe('Tool to execute'),
+  args: z.record(z.unknown()).optional()
+    .describe('Tool arguments. Use "$stepName.path.to.value" to reference previous step results'),
+  on_error: z.enum(['abort', 'continue']).optional()
+    .describe('Error handling: "abort" stops the workflow (default), "continue" skips to next step'),
+});
+
+type Step = z.infer<typeof stepSchema>;
+
+/**
+ * Resolve template references like "$find.dashboards[0].id" against workflow context.
+ */
+function resolveValue(value: unknown, context: Record<string, unknown>): unknown {
+  if (typeof value === 'string' && value.startsWith('$')) {
+    const path = value.slice(1); // Remove leading $
+    return getNestedValue(context, path);
+  }
+  if (Array.isArray(value)) {
+    return value.map(v => resolveValue(v, context));
+  }
+  if (value !== null && typeof value === 'object') {
+    const resolved: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      resolved[k] = resolveValue(v, context);
+    }
+    return resolved;
+  }
+  return value;
+}
+
+/**
+ * Navigate a nested object by dot/bracket path.
+ * Supports: "step.dashboards[0].id", "step.results[2].name"
+ */
+function getNestedValue(obj: unknown, path: string): unknown {
+  const parts = path.split(/\.|\[(\d+)\]/).filter(Boolean);
+  let current: unknown = obj;
+  for (const part of parts) {
+    if (current === null || current === undefined) return undefined;
+    if (Array.isArray(current)) {
+      const idx = parseInt(part, 10);
+      if (!isNaN(idx)) {
+        current = current[idx];
+        continue;
+      }
+    }
+    if (typeof current === 'object' && current !== null) {
+      current = (current as Record<string, unknown>)[part];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}
+
+async function executeStep(
+  step: Step,
+  ctx: ToolContext,
+  workflowContext: Record<string, unknown>,
+): Promise<unknown> {
+  const args = step.args ? resolveValue(step.args, workflowContext) as Record<string, unknown> : {};
+
+  switch (step.tool) {
+    case 'list_dashboards': {
+      const dashboards = await ctx.metabaseClient.getDashboards();
+      return {
+        count: dashboards.length,
+        dashboards: dashboards.map(d => ({
+          id: d.id, name: d.name, description: d.description, collection_id: d.collection_id,
+        })),
+      };
+    }
+    case 'get_dashboard': {
+      const id = args.dashboard_id as number;
+      return await ctx.metabaseClient.getDashboard(id);
+    }
+    case 'list_cards': {
+      let cards = await ctx.metabaseClient.getCards();
+      if (args.collection_id !== undefined) {
+        cards = cards.filter(c => c.collection_id === (args.collection_id as number));
+      }
+      const limit = (args.limit as number) ?? 100;
+      cards = cards.slice(0, limit);
+      return {
+        count: cards.length,
+        cards: cards.map(c => ({
+          id: c.id, name: c.name, display: c.display, database_id: c.database_id, collection_id: c.collection_id,
+        })),
+      };
+    }
+    case 'get_card': {
+      const id = args.card_id as number;
+      return await ctx.metabaseClient.getCard(id);
+    }
+    case 'execute_card': {
+      const id = args.card_id as number;
+      const params = args.parameters as Record<string, unknown> | undefined;
+      const result = await ctx.metabaseClient.executeCard(id, params);
+      return formatQueryResult(
+        result.data.cols,
+        result.data.rows,
+        result.row_count,
+        {
+          format: 'compact',
+          limit: (args.limit as number) ?? ctx.config.metabase.maxRows,
+          offset: 0,
+        }
+      );
+    }
+    case 'list_databases': {
+      const databases = await ctx.metabaseClient.getDatabases();
+      return {
+        count: databases.length,
+        databases: databases.map(d => ({ id: d.id, name: d.name, engine: d.engine })),
+      };
+    }
+    case 'get_database_schema': {
+      const id = args.database_id as number;
+      const schema = await ctx.schemaManager.getSchema(id);
+      return formatSchemaResult(schema, {
+        detail: args.detail as 'full' | 'tables_only' | undefined,
+        format: 'compact',
+        tables: args.tables as string[] | undefined,
+      });
+    }
+    case 'execute_query': {
+      const dbId = args.database_id as number;
+      const sql = args.sql as string;
+      const validation = ctx.sqlGuardrails.validate(sql);
+      if (!validation.valid) {
+        throw new SQLValidationError('SQL validation failed', validation.errors, validation.warnings);
+      }
+      const result = await ctx.metabaseClient.executeQuery(dbId, validation.sanitizedSQL);
+      return formatQueryResult(
+        result.data.cols,
+        result.data.rows,
+        result.row_count,
+        {
+          format: 'compact',
+          limit: (args.limit as number) ?? ctx.config.metabase.maxRows,
+          offset: 0,
+        }
+      );
+    }
+    case 'search_content': {
+      const query = args.query as string;
+      const type = args.type as string | undefined;
+      const results = await ctx.metabaseClient.search(query, type ? [type] : undefined);
+      return {
+        count: results.length,
+        results: results.map(r => ({
+          id: r.id, name: r.name, description: r.description,
+          model: r.model, collection_id: r.collection_id,
+        })),
+      };
+    }
+    case 'get_collections': {
+      const collections = await ctx.metabaseClient.getCollections();
+      return {
+        count: collections.length,
+        collections: collections.map(c => ({
+          id: c.id, name: c.name, description: c.description,
+        })),
+      };
+    }
+    default:
+      throw new Error(`Unknown tool: ${step.tool}`);
+  }
+}
+
+export function registerWorkflowTools(server: McpServer, ctx: ToolContext): void {
+  server.tool(
+    'run_workflow',
+    `Execute a multi-step workflow pipeline in a single call. Steps run sequentially and can reference previous step results using "$stepName.path" syntax. Example: search for dashboards, then get details of the first result, then execute its cards — all in one call. Max ${MAX_STEPS} steps.`,
+    {
+      steps: z.array(stepSchema).min(1).max(MAX_STEPS)
+        .describe('Ordered pipeline steps. Each step can reference results from previous steps.'),
+    },
+    { title: 'Run Workflow', readOnlyHint: true, openWorldHint: true },
+    async ({ steps }) => {
+      try {
+        ctx.rateLimiter.checkLimit('read');
+
+        // Validate step names are unique
+        const names = new Set<string>();
+        for (const step of steps) {
+          if (names.has(step.name)) {
+            return createErrorResponse(new Error(`Duplicate step name: "${step.name}"`));
+          }
+          names.add(step.name);
+        }
+
+        const workflowContext: Record<string, unknown> = {};
+        const stepResults: Array<{
+          name: string;
+          tool: string;
+          success: boolean;
+          result?: unknown;
+          error?: string;
+          duration_ms: number;
+        }> = [];
+
+        const workflowStart = Date.now();
+
+        for (const step of steps) {
+          const stepStart = Date.now();
+          try {
+            const result = await executeStep(step, ctx, workflowContext);
+            workflowContext[step.name] = result;
+            stepResults.push({
+              name: step.name,
+              tool: step.tool,
+              success: true,
+              result,
+              duration_ms: Date.now() - stepStart,
+            });
+          } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            stepResults.push({
+              name: step.name,
+              tool: step.tool,
+              success: false,
+              error: message,
+              duration_ms: Date.now() - stepStart,
+            });
+
+            if (step.on_error !== 'continue') {
+              // Abort: return partial results
+              ctx.auditLogger.logFailure('run_workflow', error as Error, {
+                abortedAt: step.name,
+                completedSteps: stepResults.length - 1,
+              });
+              return createCompactTextResponse({
+                completed: false,
+                aborted_at: step.name,
+                total_steps: steps.length,
+                completed_steps: stepResults.length - 1,
+                duration_ms: Date.now() - workflowStart,
+                steps: stepResults,
+              });
+            }
+          }
+        }
+
+        const succeeded = stepResults.filter(r => r.success).length;
+        ctx.auditLogger.logSuccess('run_workflow', {
+          totalSteps: steps.length,
+          succeeded,
+          failed: steps.length - succeeded,
+          durationMs: Date.now() - workflowStart,
+        });
+
+        return createCompactTextResponse({
+          completed: true,
+          total_steps: steps.length,
+          succeeded,
+          failed: steps.length - succeeded,
+          duration_ms: Date.now() - workflowStart,
+          steps: stepResults,
+        });
+      } catch (error) {
+        ctx.auditLogger.logFailure('run_workflow', error as Error);
+        return createErrorResponse(error as Error);
+      }
+    }
+  );
+}

--- a/src/tools/write-tools.ts
+++ b/src/tools/write-tools.ts
@@ -6,7 +6,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import type { ToolContext } from './types.js';
-import { createTextResponse, createErrorResponse } from './types.js';
+import { createErrorResponse, createCompactTextResponse } from './types.js';
 import { SQLValidationError } from '../utils/errors.js';
 
 export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
@@ -52,7 +52,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
 
         ctx.auditLogger.logSuccess('create_card', { card_id: card.id, name });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           success: true,
           card: {
             id: card.id,
@@ -114,7 +114,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
         const card = await ctx.metabaseClient.updateCard(card_id, updates);
         ctx.auditLogger.logSuccess('update_card', { card_id, updates: Object.keys(updates) });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           success: true,
           card: {
             id: card.id,
@@ -146,7 +146,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
         await ctx.metabaseClient.deleteCard(card_id);
         ctx.auditLogger.logSuccess('delete_card', { card_id });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           success: true,
           message: `Card ${card_id} has been archived`,
         });
@@ -181,7 +181,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
 
         ctx.auditLogger.logSuccess('create_dashboard', { dashboard_id: dashboard.id, name });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           success: true,
           dashboard: {
             id: dashboard.id,
@@ -222,7 +222,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
         const dashboard = await ctx.metabaseClient.updateDashboard(dashboard_id, updates);
         ctx.auditLogger.logSuccess('update_dashboard', { dashboard_id, updates: Object.keys(updates) });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           success: true,
           dashboard: {
             id: dashboard.id,
@@ -253,7 +253,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
         await ctx.metabaseClient.deleteDashboard(dashboard_id);
         ctx.auditLogger.logSuccess('delete_dashboard', { dashboard_id });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           success: true,
           message: `Dashboard ${dashboard_id} has been archived`,
         });
@@ -292,7 +292,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
 
         ctx.auditLogger.logSuccess('add_card_to_dashboard', { dashboard_id, card_id });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           success: true,
           message: `Card ${card_id} added to dashboard ${dashboard_id}`,
         });
@@ -320,7 +320,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
         await ctx.metabaseClient.removeCardFromDashboard(dashboard_id, dashcard_id);
         ctx.auditLogger.logSuccess('remove_card_from_dashboard', { dashboard_id, dashcard_id });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           success: true,
           message: `Card removed from dashboard ${dashboard_id}`,
         });
@@ -357,7 +357,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
 
         ctx.auditLogger.logSuccess('create_collection', { collection_id: collection.id, name });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           success: true,
           collection: {
             id: collection.id,
@@ -397,7 +397,7 @@ export function registerWriteTools(server: McpServer, ctx: ToolContext): void {
 
         ctx.auditLogger.logSuccess('move_to_collection', { item_type, item_id, collection_id });
 
-        return createTextResponse({
+        return createCompactTextResponse({
           success: true,
           message: `${item_type} ${item_id} moved to collection ${collection_id}`,
         });

--- a/tests/integration/batch-tools.test.ts
+++ b/tests/integration/batch-tools.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Batch Tools Integration Tests
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerBatchTools } from '../../src/tools/batch-tools.js';
+import type { ToolContext } from '../../src/tools/types.js';
+import { SQLGuardrails } from '../../src/security/sql-guardrails.js';
+import { TieredRateLimiter } from '../../src/security/rate-limiter.js';
+import { AuditLogger } from '../../src/security/audit-logger.js';
+import { SchemaManager } from '../../src/utils/schema-manager.js';
+import { Logger } from '../../src/config.js';
+import { createMockMetabaseClient, createTestConfig } from '../setup.js';
+import {
+  sampleDashboards,
+  sampleCards,
+  sampleDatabases,
+  sampleCollections,
+  sampleQueryResult,
+} from '../fixtures/index.js';
+
+describe('Batch Tools Integration', () => {
+  let server: McpServer;
+  let mockClient: ReturnType<typeof createMockMetabaseClient>;
+  let context: ToolContext;
+  let registeredTools: Map<string, any>;
+
+  beforeEach(() => {
+    server = new McpServer({ name: 'test', version: '1.0.0' });
+    mockClient = createMockMetabaseClient();
+
+    mockClient.getDashboards.mockResolvedValue(sampleDashboards);
+    mockClient.getDashboard.mockResolvedValue(sampleDashboards[0]);
+    mockClient.getCards.mockResolvedValue(sampleCards);
+    mockClient.getCard.mockResolvedValue(sampleCards[0]);
+    mockClient.executeCard.mockResolvedValue(sampleQueryResult);
+    mockClient.getDatabases.mockResolvedValue(sampleDatabases);
+    mockClient.executeQuery.mockResolvedValue(sampleQueryResult);
+    mockClient.getCollections.mockResolvedValue(sampleCollections);
+    mockClient.search.mockResolvedValue([]);
+
+    const config = createTestConfig();
+
+    context = {
+      config,
+      metabaseClient: mockClient as any,
+      llmService: null,
+      sqlGuardrails: new SQLGuardrails(config.security),
+      rateLimiter: new TieredRateLimiter(),
+      auditLogger: new AuditLogger(),
+      schemaManager: new SchemaManager(mockClient as any),
+      logger: new Logger('error'),
+    };
+
+    registeredTools = new Map();
+    const originalTool = server.tool.bind(server);
+    vi.spyOn(server, 'tool').mockImplementation((name: string, ...args: any[]) => {
+      const handler = args[args.length - 1];
+      registeredTools.set(name, { args, handler });
+      return originalTool(name, ...args);
+    });
+
+    registerBatchTools(server, context);
+  });
+
+  describe('batch_execute', () => {
+    it('registers the tool', () => {
+      expect(registeredTools.has('batch_execute')).toBe(true);
+    });
+
+    it('executes multiple operations in parallel', async () => {
+      const handler = registeredTools.get('batch_execute')?.handler;
+      const result = await handler({
+        operations: [
+          { tool: 'list_dashboards' },
+          { tool: 'list_databases' },
+        ],
+      });
+
+      expect(result.isError).toBeFalsy();
+      const data = JSON.parse(result.content[0].text);
+      expect(data.total).toBe(2);
+      expect(data.succeeded).toBe(2);
+      expect(data.failed).toBe(0);
+      expect(data.results).toHaveLength(2);
+    });
+
+    it('executes get_dashboard by ID', async () => {
+      const handler = registeredTools.get('batch_execute')?.handler;
+      const result = await handler({
+        operations: [
+          { tool: 'get_dashboard', args: { dashboard_id: 1 } },
+          { tool: 'get_card', args: { card_id: 1 } },
+        ],
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.succeeded).toBe(2);
+      expect(mockClient.getDashboard).toHaveBeenCalledWith(1);
+      expect(mockClient.getCard).toHaveBeenCalledWith(1);
+    });
+
+    it('handles partial failures gracefully', async () => {
+      mockClient.getDashboard.mockRejectedValueOnce(new Error('Not found'));
+
+      const handler = registeredTools.get('batch_execute')?.handler;
+      const result = await handler({
+        operations: [
+          { tool: 'get_dashboard', args: { dashboard_id: 999 } },
+          { tool: 'list_databases' },
+        ],
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.total).toBe(2);
+      expect(data.succeeded).toBe(1);
+      expect(data.failed).toBe(1);
+      expect(data.results[0].success).toBe(false);
+      expect(data.results[0].error).toBe('Not found');
+      expect(data.results[1].success).toBe(true);
+    });
+
+    it('executes SQL queries with validation', async () => {
+      const handler = registeredTools.get('batch_execute')?.handler;
+      const result = await handler({
+        operations: [
+          { tool: 'execute_query', args: { database_id: 1, sql: 'SELECT * FROM users' } },
+        ],
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.succeeded).toBe(1);
+    });
+
+    it('rejects dangerous SQL in batch', async () => {
+      const handler = registeredTools.get('batch_execute')?.handler;
+      const result = await handler({
+        operations: [
+          { tool: 'execute_query', args: { database_id: 1, sql: 'DROP TABLE users' } },
+        ],
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.succeeded).toBe(0);
+      expect(data.failed).toBe(1);
+      expect(data.results[0].error).toContain('SQL validation failed');
+    });
+
+    it('executes search_content operations', async () => {
+      mockClient.search.mockResolvedValue([
+        { id: 1, name: 'Revenue', description: null, model: 'card', collection_id: 1, collection_name: 'Analytics' },
+      ]);
+
+      const handler = registeredTools.get('batch_execute')?.handler;
+      const result = await handler({
+        operations: [
+          { tool: 'search_content', args: { query: 'revenue' } },
+        ],
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.succeeded).toBe(1);
+      expect(data.results[0].result.count).toBe(1);
+    });
+
+    it('returns compact JSON responses', async () => {
+      const handler = registeredTools.get('batch_execute')?.handler;
+      const result = await handler({
+        operations: [{ tool: 'list_dashboards' }],
+      });
+
+      // Compact = no indentation
+      expect(result.content[0].text).not.toContain('\n');
+    });
+
+    it('includes timing information', async () => {
+      const handler = registeredTools.get('batch_execute')?.handler;
+      const result = await handler({
+        operations: [{ tool: 'list_dashboards' }],
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.duration_ms).toBeDefined();
+      expect(typeof data.duration_ms).toBe('number');
+    });
+  });
+});

--- a/tests/integration/workflow-tools.test.ts
+++ b/tests/integration/workflow-tools.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Workflow Tools Integration Tests
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerWorkflowTools } from '../../src/tools/workflow-tools.js';
+import type { ToolContext } from '../../src/tools/types.js';
+import { SQLGuardrails } from '../../src/security/sql-guardrails.js';
+import { TieredRateLimiter } from '../../src/security/rate-limiter.js';
+import { AuditLogger } from '../../src/security/audit-logger.js';
+import { SchemaManager } from '../../src/utils/schema-manager.js';
+import { Logger } from '../../src/config.js';
+import { createMockMetabaseClient, createTestConfig } from '../setup.js';
+import {
+  sampleDashboards,
+  sampleCards,
+  sampleDatabases,
+  sampleCollections,
+  sampleQueryResult,
+} from '../fixtures/index.js';
+
+describe('Workflow Tools Integration', () => {
+  let server: McpServer;
+  let mockClient: ReturnType<typeof createMockMetabaseClient>;
+  let context: ToolContext;
+  let registeredTools: Map<string, any>;
+
+  beforeEach(() => {
+    server = new McpServer({ name: 'test', version: '1.0.0' });
+    mockClient = createMockMetabaseClient();
+
+    mockClient.getDashboards.mockResolvedValue(sampleDashboards);
+    mockClient.getDashboard.mockResolvedValue(sampleDashboards[0]);
+    mockClient.getCards.mockResolvedValue(sampleCards);
+    mockClient.getCard.mockResolvedValue(sampleCards[0]);
+    mockClient.executeCard.mockResolvedValue(sampleQueryResult);
+    mockClient.getDatabases.mockResolvedValue(sampleDatabases);
+    mockClient.executeQuery.mockResolvedValue(sampleQueryResult);
+    mockClient.getCollections.mockResolvedValue(sampleCollections);
+    mockClient.search.mockResolvedValue([]);
+
+    const config = createTestConfig();
+
+    context = {
+      config,
+      metabaseClient: mockClient as any,
+      llmService: null,
+      sqlGuardrails: new SQLGuardrails(config.security),
+      rateLimiter: new TieredRateLimiter(),
+      auditLogger: new AuditLogger(),
+      schemaManager: new SchemaManager(mockClient as any),
+      logger: new Logger('error'),
+    };
+
+    registeredTools = new Map();
+    const originalTool = server.tool.bind(server);
+    vi.spyOn(server, 'tool').mockImplementation((name: string, ...args: any[]) => {
+      const handler = args[args.length - 1];
+      registeredTools.set(name, { args, handler });
+      return originalTool(name, ...args);
+    });
+
+    registerWorkflowTools(server, context);
+  });
+
+  describe('run_workflow', () => {
+    it('registers the tool', () => {
+      expect(registeredTools.has('run_workflow')).toBe(true);
+    });
+
+    it('executes a single step workflow', async () => {
+      const handler = registeredTools.get('run_workflow')?.handler;
+      const result = await handler({
+        steps: [
+          { name: 'dashboards', tool: 'list_dashboards' },
+        ],
+      });
+
+      expect(result.isError).toBeFalsy();
+      const data = JSON.parse(result.content[0].text);
+      expect(data.completed).toBe(true);
+      expect(data.total_steps).toBe(1);
+      expect(data.succeeded).toBe(1);
+      expect(data.steps[0].name).toBe('dashboards');
+      expect(data.steps[0].success).toBe(true);
+    });
+
+    it('chains steps with output references', async () => {
+      mockClient.getDashboard.mockResolvedValue(sampleDashboards[0]);
+
+      const handler = registeredTools.get('run_workflow')?.handler;
+      const result = await handler({
+        steps: [
+          { name: 'find', tool: 'list_dashboards' },
+          {
+            name: 'details',
+            tool: 'get_dashboard',
+            args: { dashboard_id: '$find.dashboards[0].id' },
+          },
+        ],
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.completed).toBe(true);
+      expect(data.succeeded).toBe(2);
+      expect(mockClient.getDashboard).toHaveBeenCalledWith(1);
+    });
+
+    it('handles nested path references', async () => {
+      mockClient.search.mockResolvedValue([
+        { id: 42, name: 'Revenue Card', model: 'card', collection_id: 1, collection_name: 'Analytics', description: null },
+      ]);
+
+      const handler = registeredTools.get('run_workflow')?.handler;
+      const result = await handler({
+        steps: [
+          { name: 'search', tool: 'search_content', args: { query: 'revenue' } },
+          {
+            name: 'card',
+            tool: 'get_card',
+            args: { card_id: '$search.results[0].id' },
+          },
+        ],
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.completed).toBe(true);
+      expect(mockClient.getCard).toHaveBeenCalledWith(42);
+    });
+
+    it('aborts on error by default', async () => {
+      mockClient.getDashboard.mockRejectedValueOnce(new Error('Not found'));
+
+      const handler = registeredTools.get('run_workflow')?.handler;
+      const result = await handler({
+        steps: [
+          { name: 'fail', tool: 'get_dashboard', args: { dashboard_id: 999 } },
+          { name: 'never_runs', tool: 'list_databases' },
+        ],
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.completed).toBe(false);
+      expect(data.aborted_at).toBe('fail');
+      expect(data.steps).toHaveLength(1);
+      expect(mockClient.getDatabases).not.toHaveBeenCalled();
+    });
+
+    it('continues on error when on_error is "continue"', async () => {
+      mockClient.getDashboard.mockRejectedValueOnce(new Error('Not found'));
+
+      const handler = registeredTools.get('run_workflow')?.handler;
+      const result = await handler({
+        steps: [
+          { name: 'fail', tool: 'get_dashboard', args: { dashboard_id: 999 }, on_error: 'continue' },
+          { name: 'succeeds', tool: 'list_databases' },
+        ],
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.completed).toBe(true);
+      expect(data.succeeded).toBe(1);
+      expect(data.failed).toBe(1);
+      expect(data.steps).toHaveLength(2);
+      expect(data.steps[0].success).toBe(false);
+      expect(data.steps[1].success).toBe(true);
+    });
+
+    it('rejects duplicate step names', async () => {
+      const handler = registeredTools.get('run_workflow')?.handler;
+      const result = await handler({
+        steps: [
+          { name: 'step1', tool: 'list_dashboards' },
+          { name: 'step1', tool: 'list_databases' },
+        ],
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Duplicate step name');
+    });
+
+    it('validates SQL in execute_query steps', async () => {
+      const handler = registeredTools.get('run_workflow')?.handler;
+      const result = await handler({
+        steps: [
+          {
+            name: 'query',
+            tool: 'execute_query',
+            args: { database_id: 1, sql: 'DROP TABLE users' },
+          },
+        ],
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.completed).toBe(false);
+      expect(data.steps[0].success).toBe(false);
+      expect(data.steps[0].error).toContain('SQL validation failed');
+    });
+
+    it('executes a multi-step data exploration workflow', async () => {
+      mockClient.search.mockResolvedValue([
+        { id: 1, name: 'Revenue', model: 'card', collection_id: 1, collection_name: 'Analytics', description: null },
+      ]);
+
+      const handler = registeredTools.get('run_workflow')?.handler;
+      const result = await handler({
+        steps: [
+          { name: 'search', tool: 'search_content', args: { query: 'revenue', type: 'card' } },
+          { name: 'card', tool: 'get_card', args: { card_id: '$search.results[0].id' } },
+          { name: 'data', tool: 'execute_card', args: { card_id: '$search.results[0].id' } },
+        ],
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.completed).toBe(true);
+      expect(data.succeeded).toBe(3);
+      expect(data.total_steps).toBe(3);
+    });
+
+    it('returns compact JSON responses', async () => {
+      const handler = registeredTools.get('run_workflow')?.handler;
+      const result = await handler({
+        steps: [{ name: 'test', tool: 'list_dashboards' }],
+      });
+
+      // Compact = no indentation/newlines in JSON
+      expect(result.content[0].text).not.toContain('\n');
+    });
+
+    it('includes per-step timing', async () => {
+      const handler = registeredTools.get('run_workflow')?.handler;
+      const result = await handler({
+        steps: [
+          { name: 'step1', tool: 'list_dashboards' },
+          { name: 'step2', tool: 'list_databases' },
+        ],
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.duration_ms).toBeDefined();
+      for (const step of data.steps) {
+        expect(step.duration_ms).toBeDefined();
+        expect(typeof step.duration_ms).toBe('number');
+      }
+    });
+
+    it('resolves array references in args', async () => {
+      const handler = registeredTools.get('run_workflow')?.handler;
+      const result = await handler({
+        steps: [
+          { name: 'dbs', tool: 'list_databases' },
+          {
+            name: 'cards',
+            tool: 'list_cards',
+            args: {},
+          },
+        ],
+      });
+
+      const data = JSON.parse(result.content[0].text);
+      expect(data.completed).toBe(true);
+      expect(data.succeeded).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **`batch_execute` tool** — run up to 20 read operations in parallel in a single call, reducing multi-turn round trips. Supports all read tools (get_dashboard, execute_card, execute_query, search_content, etc.)
- **`run_workflow` tool** — composable multi-step pipelines with `$stepName.path` output references between steps. Enables "search dashboards → get details → execute cards → analyze" in one call. Supports abort/continue error handling per step. Inspired by [Apple CodeAct](https://machinelearning.apple.com/research/codeact) and [Cloudflare Code Mode](https://blog.cloudflare.com/code-mode/)
- **Default compact responses** — all tools now return compact JSON by default (~50% token reduction). Users can opt into pretty-printed output with `format="default"`
- **Version bump to 1.3.0**

### Competitive differentiation
No other Metabase MCP server (official or community) offers workflow composition or batch execution. This is a first-mover feature.

### New files
- `src/tools/batch-tools.ts` — batch_execute implementation
- `src/tools/workflow-tools.ts` — run_workflow implementation with path resolver
- `tests/integration/batch-tools.test.ts` — 9 tests
- `tests/integration/workflow-tools.test.ts` — 12 tests

## Test plan
- [x] All 406 tests pass (385 existing + 21 new)
- [x] TypeScript builds cleanly
- [x] Batch tool handles partial failures gracefully
- [x] Workflow tool chains step outputs via `$step.path` references
- [x] Workflow aborts on error by default, continues when `on_error: "continue"`
- [x] SQL guardrails enforced in both batch and workflow execute_query
- [x] Compact responses verified (no newlines in JSON output)
- [ ] Manual testing with live Metabase instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)